### PR TITLE
feat: add Trust Wallet agent API skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,165 @@
-# tw-agent-skills
+# Trust Wallet Agent Skills
 
-> **Note:** This repository contains Trust Wallet's open source skills for Claude Code. For information about the Agent Skills standard, see [agentskills.io](http://agentskills.io).
+AI agent skills for Trust Wallet APIs — wallet management, token transfers, swaps, DCA, limit orders, price alerts, balances, market data, history, security, and fiat on/off-ramp — across **100+ chains**.
 
-Skills are folders of instructions and references that Claude loads to improve performance on specialized tasks. These skills teach Claude how to work with Trust Wallet's libraries and developer platform in a repeatable, accurate way.
+## Install
 
-For more information, check out:
-- [What are skills?](https://support.claude.com/en/articles/12512176-what-are-skills)
-- [Using skills in Claude](https://support.claude.com/en/articles/12512180-using-skills-in-claude)
-- [How to create custom skills](https://support.claude.com/en/articles/12512198-creating-custom-skills)
-
-# About This Repository
-
-This repository contains skills for building with Trust Wallet's open source projects — Web3 providers, wallet signing, smart contract wallets, token assets, and the developer platform.
-
-Each skill is self-contained in its own folder with a `SKILL.md` file. Browse through to understand the patterns or contribute new skills.
-
-# Skill Sets
-
-- [./skills](./skills) — Trust Wallet developer skills
-- [./spec](./spec) — Agent Skills specification
-- [./template](./template) — Skill template
-
-# Try in Claude Code
-
-## Installation
-
-Register this repository as a Claude Code plugin marketplace:
-
-```
-/plugin marketplace add trustwallet/tw-agent-skills
+```bash
+npx skills add trustwallet/tw-agent-skills
 ```
 
-## Installing Skills
+This auto-detects your coding agent. To install for a specific agent:
 
-Install the web3-skills plugin (all Trust Wallet skills):
+```bash
+# Claude Code
+npx skills add trustwallet/tw-agent-skills -a claude-code
 
-```
-/plugin install web3-skills@tw-agent-skills
-```
+# Cursor
+npx skills add trustwallet/tw-agent-skills -a cursor
 
-Or browse and install interactively:
+# Codex CLI
+npx skills add trustwallet/tw-agent-skills -a codex
 
-1. Run `/plugin browse`
-2. Select `tw-agent-skills`
-3. Select `web3-skills`
-4. Select `Install now`
+# Windsurf
+npx skills add trustwallet/tw-agent-skills -a windsurf
 
-## Updating
+# GitHub Copilot
+npx skills add trustwallet/tw-agent-skills -a github-copilot
 
-```
-/plugin marketplace update tw-agent-skills
-/plugin install web3-skills@tw-agent-skills
-```
+# Cline
+npx skills add trustwallet/tw-agent-skills -a cline
 
-> **Note:** Restart Claude Code after installing or updating plugins.
+# OpenCode
+npx skills add trustwallet/tw-agent-skills -a opencode
 
-## Using Skills
+# Roo
+npx skills add trustwallet/tw-agent-skills -a roo
 
-After installing, mention the skill in your request:
-
-- "Use the trust-web3-provider skill to help me add Solana support"
-- "Use the wallet-core skill to implement transaction signing in Swift"
-- "Use the assets skill to check the logo CDN URL for USDC on Base"
-- "Use the barz skill to add a new facet to my smart contract wallet"
-- "Use the trust-developer skill to set up WalletConnect in my dApp"
-
-# Available Skills
-
-### web3-skills Plugin
-
-| Skill | Description |
-|-------|-------------|
-| **[trust-web3-provider](./skills/trust-web3-provider/SKILL.md)** | Integrate and build on Trust Wallet's Web3 provider library — Ethereum (EIP-1193), Solana (Wallet Standard), Cosmos (Keplr), Bitcoin, Aptos, TON, Tron |
-| **[wallet-core](./skills/wallet-core/SKILL.md)** | HD wallet creation, address derivation, and transaction signing across 140+ blockchains in Swift, Kotlin, TypeScript, and Go |
-| **[assets](./skills/assets/SKILL.md)** | Look up token logos and metadata, list assets by chain, use CDN URLs, and contribute new assets to trustwallet/assets |
-| **[barz](./skills/barz/SKILL.md)** | Build with and contribute to Barz — Trust Wallet's modular ERC-4337 smart contract wallet using the Diamond proxy pattern |
-| **[trust-developer](./skills/trust-developer/SKILL.md)** | Trust Wallet developer platform — deep links, browser extension detection, and WalletConnect integration |
-
-# Creating a Skill
-
-Skills are simple — a folder with a `SKILL.md` file containing YAML frontmatter and instructions:
-
-```markdown
----
-name: my-skill-name
-description: A clear description of what this skill does and when to use it
----
-
-# My Skill Name
-
-[Instructions for Claude to follow when this skill is active]
+# Any other supported agent
+npx skills add trustwallet/tw-agent-skills -a <agent-name>
 ```
 
-The frontmatter requires only two fields:
-- `name` — unique identifier (lowercase, hyphens for spaces)
-- `description` — what the skill does and **when Claude should activate it**
+Install a single skill:
 
-Copy `template/SKILL.md` as a starting point.
+```bash
+npx skills add trustwallet/tw-agent-skills -s swap-quote
+```
 
-## Contributing
+List available skills without installing:
 
-1. Fork this repo
-2. Add your skill to `skills/<your-skill>/SKILL.md`
-3. Add its path to `.claude-plugin/marketplace.json` under the `skills` array
-4. Open a PR
+```bash
+npx skills add trustwallet/tw-agent-skills -l
+```
+
+## Prerequisites
+
+You need Trust Wallet API credentials. Get them at [portal.trustwallet.com](https://portal.trustwallet.com).
+
+Set them as environment variables or in a `.env` file:
+
+```env
+TWAK_ACCESS_ID=your_access_id
+TWAK_HMAC_SECRET=your_hmac_secret
+```
+
+> **Security:** Add `.env` to `.gitignore`. Never commit credentials.
+
+See the [setup skill](skills/setup/SKILL.md) for the full HMAC-SHA256 signing algorithm with code examples in JavaScript and Python.
+
+## Skills
+
+| Skill | Actions | Description |
+|-------|---------|-------------|
+| [`setup`](skills/setup/SKILL.md) | — | Authentication (HMAC-SHA256), wallet password, base URLs, 100+ supported chains |
+| [`wallet`](skills/wallet/SKILL.md) | 5 | Create wallet, get addresses, check balances, WalletConnect |
+| [`balance`](skills/balance/SKILL.md) | 4 | Native balance, token holdings, asset search, asset info |
+| [`transfer`](skills/transfer/SKILL.md) | 3 | Token transfers with ENS resolution, ERC-20 approvals, allowances |
+| [`swap-quote`](skills/swap-quote/SKILL.md) | 4 | Swap quotes, step transactions, providers, and domains via Amber |
+| [`market-data`](skills/market-data/SKILL.md) | 3 | Token prices (CMC + CoinGecko index), trending listings by 16+ categories |
+| [`history`](skills/history/SKILL.md) | 2 | Transaction history and details |
+| [`security`](skills/security/SKILL.md) | 2 | Address validation and token risk analysis |
+| [`onramp`](skills/onramp/SKILL.md) | 4 | Fiat buy/sell quotes and checkout URLs |
+| [`alerts`](skills/alerts/SKILL.md) | 4 | Price alerts with above/below conditions |
+| [`automations`](skills/automations/SKILL.md) | 4 | DCA recurring buys and limit orders |
+
+**35 actions** across 11 skills covering 100+ supported chains.
+
+## Workflow
+
+Skills build on each other:
+
+```
+setup → wallet → balance → transfer
+                        → swap-quote → automations (DCA / limit orders)
+                        → market-data → alerts
+                        → history
+                        → security
+                        → onramp
+```
+
+1. Start with `setup` to understand authentication and wallet password
+2. Use `wallet` to create or connect a wallet and get addresses
+3. Use `balance` to check wallet holdings
+4. Use `market-data` for prices and token discovery
+5. Use `security` to validate addresses and check token risk before transacting
+6. Use `swap-quote` to get quotes and transaction data
+7. Use `transfer` to send tokens or manage approvals
+8. Use `alerts` to set price notifications
+9. Use `automations` to set up DCA or limit orders
+10. Use `onramp` for fiat buy/sell flows
+
+## Base URLs
+
+| Base URL | Auth | Purpose |
+|----------|------|---------|
+| `https://gateway.us.trustwallet.com` | HMAC-SHA256 | Balance, assets, security, history, on/off-ramp, market listings |
+| `https://api.trustwallet.com` | HMAC-SHA256 | Swap quotes, transactions, providers, domains (Amber) |
+| `https://market.trustwallet.com` | None | Token prices (index from CoinMarketCap + CoinGecko) |
+
+## Asset ID Format
+
+Trust Wallet uses a compact asset ID format across all APIs:
+
+- **Native coin**: `c{coinId}` — e.g., `c60` (ETH), `c714` (BNB), `c501` (SOL)
+- **Token**: `c{coinId}_t{contractAddress}` — e.g., `c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` (USDC on Ethereum)
+
+The `coinId` follows the [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) standard.
+
+### Common Coin IDs
+
+| Chain | Coin ID | Symbol |
+|-------|---------|--------|
+| Ethereum | 60 | ETH |
+| BSC | 714 | BNB |
+| Polygon | 966 | MATIC |
+| Solana | 501 | SOL |
+| Bitcoin | 0 | BTC |
+| Arbitrum | 10042221 | ETH |
+| Base | 10008453 | ETH |
+| Optimism | 10000070 | ETH |
+| Avalanche | 10009000 | AVAX |
+| Tron | 195 | TRX |
+
+See the [setup skill](skills/setup/SKILL.md) for the complete list of 100+ supported chains.
+
+## Swap Providers
+
+The Amber aggregator routes through 10+ DEX and bridge providers:
+
+**DEX:** 1inch, KyberSwap, 0x, Jupiter (Solana), THORChain (Bitcoin/UTXO)
+**Bridges:** Stargate, Synapse, Squid Router, Rango, SWFT
+**Internal:** LiquidMesh (Amber's routing engine)
+
+See the [swap-quote skill](skills/swap-quote/SKILL.md) for per-chain provider availability.
+
+## What's NOT Included
+
+These skills document the Trust Wallet agent APIs. The following are out of scope:
+
+- Raw private key management (the agent wallet handles this securely)
+- Custom smart contract deployment
+- NFT-specific operations
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@trustwallet/tw-agent-skills",
+  "version": "0.1.0",
+  "description": "Trust Wallet API skills for AI agents — wallet, transfers, swaps, DCA, limit orders, alerts, balance, market data, history, security, and on/off-ramp across 100+ chains",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trustwallet/tw-agent-skills"
+  },
+  "keywords": [
+    "trust-wallet",
+    "crypto",
+    "blockchain",
+    "ai-agent",
+    "skills",
+    "mcp",
+    "langchain",
+    "swap",
+    "defi"
+  ],
+  "files": [
+    "skills/",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/skills/alerts/SKILL.md
+++ b/skills/alerts/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: alerts
+description: Create and manage price alerts for any token — get notified when a token's price goes above or below a target. Use this whenever someone wants to set a price alert, track token prices, get notified about price movements, or manage their existing alerts.
+---
+
+# Price Alerts
+
+Create price alerts that trigger when a token's price crosses a target threshold. Alerts are stored locally at `~/.tw-agent/alerts.json` and checked against live prices from the Amber swap API.
+
+## Actions
+
+### Create Alert
+
+Set a price alert for a token. Triggers when the current price goes above or below the target.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tokenId` | string | Yes | Token ID (e.g., `c60` for ETH, `c60_t0xA0b8...` for ERC-20) |
+| `chainKey` | string | Yes | Chain key (e.g., `ethereum`, `bsc`) |
+| `condition` | string | Yes | `"above"` or `"below"` |
+| `targetPrice` | number | Yes | Target price in USD (must be positive) |
+
+**Example — alert when ETH goes above $2,500:**
+
+```json
+{
+  "tokenId": "c60",
+  "chainKey": "ethereum",
+  "condition": "above",
+  "targetPrice": 2500
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "a1b2c3d4",
+  "message": "Alert created: notify when c60 goes above $2500"
+}
+```
+
+**Example — alert when BNB drops below $500:**
+
+```json
+{
+  "tokenId": "c714",
+  "chainKey": "bsc",
+  "condition": "below",
+  "targetPrice": 500
+}
+```
+
+---
+
+### List Alerts
+
+List all price alerts, optionally filtered to active only.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `activeOnly` | boolean | No | Only show active (untriggered) alerts (default: `false`) |
+
+**Response:**
+
+```json
+{
+  "alerts": [
+    {
+      "id": "a1b2c3d4",
+      "tokenId": "c60",
+      "chainKey": "ethereum",
+      "condition": "above",
+      "targetPrice": 2500,
+      "active": true,
+      "createdAt": "2026-03-10T12:00:00Z"
+    },
+    {
+      "id": "e5f6g7h8",
+      "tokenId": "c714",
+      "chainKey": "bsc",
+      "condition": "below",
+      "targetPrice": 500,
+      "active": false,
+      "triggeredAt": "2026-03-11T08:30:00Z"
+    }
+  ],
+  "count": 2
+}
+```
+
+---
+
+### Check Alerts
+
+Check all active alerts against current live prices. Alerts that match their condition are triggered and deactivated.
+
+**Parameters:** None
+
+**Response:**
+
+```json
+{
+  "checked": 3,
+  "triggered": 1,
+  "alerts": [
+    {
+      "id": "a1b2c3d4",
+      "tokenId": "c60",
+      "chainKey": "ethereum",
+      "condition": "above",
+      "targetPrice": 2500,
+      "active": false,
+      "triggeredAt": "2026-03-11T10:00:00Z"
+    }
+  ]
+}
+```
+
+Prices are fetched from the Amber swap API (same source as `get_token_price`). Triggered alerts are automatically deactivated so they don't fire again.
+
+---
+
+### Delete Alert
+
+Remove a price alert by ID.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Alert ID to delete |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Alert a1b2c3d4 deleted"
+}
+```
+
+## Workflow
+
+1. **Create** an alert with a target price and condition
+2. **Check** alerts periodically (or use the CLI `tw-agent watch` command for continuous monitoring)
+3. **List** alerts to see which are active and which have triggered
+4. **Delete** alerts you no longer need

--- a/skills/automations/SKILL.md
+++ b/skills/automations/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: automations
+description: Set up DCA (dollar-cost averaging) recurring buys and limit orders that execute swaps when price conditions are met. Use this whenever someone wants to DCA into a token, set up recurring buys, create limit orders, buy/sell at a specific price, or automate their trading strategy.
+---
+
+# Automations — DCA & Limit Orders
+
+Create automated trading rules that execute swaps on a schedule (DCA) or when a price condition is met (limit orders). Automations are stored locally at `~/.tw-agent/automations.json` and execute swaps through the Amber aggregator.
+
+## Automation Types
+
+| Type | Description | Required Fields |
+|------|-------------|-----------------|
+| **DCA** | Recurring swap on a fixed interval | `intervalMs` |
+| **Limit** | One-time swap when price crosses a threshold | `targetPrice`, `condition` |
+
+## Actions
+
+### Create Automation
+
+Create a DCA (recurring buy) or limit order.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | `"dca"` or `"limit"` |
+| `fromToken` | string | Yes | Source token symbol or address |
+| `toToken` | string | Yes | Destination token symbol or address |
+| `chain` | string | No | Chain name (default: `ethereum`) |
+| `amount` | string | Yes | Amount of fromToken per execution |
+| `intervalMs` | number | DCA only | Interval in milliseconds (e.g., `86400000` for daily) |
+| `targetPrice` | number | Limit only | Target price in USD |
+| `condition` | string | Limit only | `"above"` or `"below"` |
+
+**Example — DCA $10 USDC into ETH every day:**
+
+```json
+{
+  "type": "dca",
+  "fromToken": "USDC",
+  "toToken": "ETH",
+  "chain": "ethereum",
+  "amount": "10",
+  "intervalMs": 86400000
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "id": "auto-abc123",
+  "summary": "DCA: 10 USDC → ETH every 24h",
+  "record": {
+    "id": "auto-abc123",
+    "type": "dca",
+    "fromToken": "USDC",
+    "toToken": "ETH",
+    "chain": "ethereum",
+    "amount": "10",
+    "intervalMs": 86400000,
+    "active": true,
+    "createdAt": "2026-03-11T12:00:00Z"
+  }
+}
+```
+
+**Example — limit order: buy ETH when AVAX drops below $9:**
+
+```json
+{
+  "type": "limit",
+  "fromToken": "USDC",
+  "toToken": "AVAX",
+  "chain": "avalanche",
+  "amount": "50",
+  "targetPrice": 9,
+  "condition": "below"
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "id": "auto-def456",
+  "summary": "Limit: swap 50 USDC → AVAX when price below $9"
+}
+```
+
+### Common Intervals
+
+| Interval | Milliseconds |
+|----------|-------------|
+| Every hour | `3600000` |
+| Every 4 hours | `14400000` |
+| Daily | `86400000` |
+| Weekly | `604800000` |
+
+---
+
+### List Automations
+
+List all automation rules, optionally filtered to active only.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `activeOnly` | boolean | No | Only show active automations (default: `true`) |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "count": 2,
+  "automations": [
+    {
+      "id": "auto-abc123",
+      "type": "dca",
+      "fromToken": "USDC",
+      "toToken": "ETH",
+      "chain": "ethereum",
+      "amount": "10",
+      "intervalMs": 86400000,
+      "active": true,
+      "lastRunAt": "2026-03-11T12:00:00Z"
+    },
+    {
+      "id": "auto-def456",
+      "type": "limit",
+      "fromToken": "USDC",
+      "toToken": "AVAX",
+      "chain": "avalanche",
+      "amount": "50",
+      "targetPrice": 9,
+      "condition": "below",
+      "active": true
+    }
+  ]
+}
+```
+
+---
+
+### Delete Automation
+
+Deactivate and remove an automation rule.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Automation ID to delete |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Automation auto-abc123 deleted"
+}
+```
+
+---
+
+### Run Automation Now
+
+Manually trigger an automation immediately, bypassing the schedule or price condition. Executes the swap through the Amber aggregator and records the result.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Automation ID to execute |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "txHash": "0x688c6129a6bf8fa8bdf39d50ad9a328b4cd1ad088947c7a9fb7712d091387abf",
+  "automationId": "auto-abc123",
+  "swapped": "10 USDC → ETH",
+  "explorer": "https://etherscan.io/tx/0x688c..."
+}
+```
+
+Requires an agent wallet with funds. The automation's `lastRunAt` is updated after execution.
+
+## Execution
+
+- **DCA automations** run at the specified interval. Use `tw-agent watch` in the CLI for continuous monitoring, or call `run_automation_now` to execute manually.
+- **Limit orders** execute once when the price condition is met, then deactivate.
+- All swaps route through the Amber aggregator (same providers as `swap` and `get_swap_quote`).
+- The agent wallet must have sufficient funds in `fromToken` for execution.

--- a/skills/balance/SKILL.md
+++ b/skills/balance/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: balance
+description: Check native coin balances, token holdings, search for tokens, and get detailed asset information across any blockchain supported by Trust Wallet.
+---
+
+# Balance & Assets
+
+Check wallet balances, token holdings, and search for assets across all supported chains.
+
+**Base URL:** `https://gateway.us.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+## Endpoints
+
+### Get Native Balance
+
+`POST /v1/balance`
+
+Get the native coin balance for one or more addresses.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | number | Yes | API version, use `2` |
+| `assets` | array | Yes | Array of `{ address, coin }` objects |
+| `assets[].address` | string | Yes | Wallet address |
+| `assets[].coin` | number | Yes | SLIP-44 coin ID (e.g., 60 for Ethereum, 714 for BSC) |
+
+```json
+{
+  "version": 2,
+  "assets": [
+    { "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "coin": 60 }
+  ]
+}
+```
+
+**Response:**
+
+```json
+{
+  "docs": [
+    {
+      "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "coin": 60,
+      "balance": "1234567890000000000",
+      "balanceUSD": "2345.67"
+    }
+  ]
+}
+```
+
+The `balance` field is in the smallest unit (wei for Ethereum, lamports for Solana, satoshis for Bitcoin). Divide by `10^decimals` for the human-readable amount.
+
+---
+
+### Get Token Holdings
+
+`POST /v1/assets`
+
+Get all token holdings for an address on a specific chain.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | number | Yes | API version, use `2` |
+| `includeDisabledAssets` | boolean | No | Include delisted tokens (default: `false`) |
+| `assets` | array | Yes | Array of `{ address, coin }` objects |
+| `assets[].address` | string | Yes | Wallet address |
+| `assets[].coin` | number | Yes | SLIP-44 coin ID |
+
+```json
+{
+  "version": 2,
+  "includeDisabledAssets": false,
+  "assets": [
+    { "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "coin": 60 }
+  ]
+}
+```
+
+**Response:**
+
+```json
+{
+  "docs": [
+    {
+      "asset_id": "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "decimals": 6,
+      "balance": "1000000000",
+      "balanceUSD": "1000.00",
+      "icon_url": "https://assets.trustwalletapp.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+    }
+  ]
+}
+```
+
+---
+
+### Search Assets
+
+`GET /v1/search/assets`
+
+Search for tokens by name, symbol, or contract address.
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | string | Yes | Search term (name, symbol, or address) |
+| `type` | string | No | Filter type, use `all` (default) |
+| `version` | string | No | API version, use `24` |
+| `limit` | number | No | Max results (default: 10) |
+| `networks` | string | No | Comma-separated SLIP-44 coin IDs to filter by chain |
+
+**Example request:**
+
+```
+GET /v1/search/assets?query=USDC&type=all&version=24&limit=10&networks=60,714
+```
+
+**Response:**
+
+```json
+{
+  "docs": [
+    {
+      "asset_id": "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "decimals": 6,
+      "icon_url": "https://assets.trustwalletapp.com/...",
+      "price": {
+        "price": 1.0,
+        "percent_change_24h": 0.01
+      }
+    }
+  ]
+}
+```
+
+---
+
+### Get Asset Info
+
+`GET /v1/assets/{assetId}`
+
+Get detailed information about a specific asset.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetId` | string | Yes | Asset ID (e.g., `c60` for ETH, `c60_t0xA0b8...` for a token) |
+
+**Example request:**
+
+```
+GET /v1/assets/c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+```
+
+**Response:**
+
+```json
+{
+  "asset_id": "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "name": "USD Coin",
+  "symbol": "USDC",
+  "decimals": 6,
+  "type": "ERC20",
+  "website": "https://www.circle.com/usdc",
+  "description": "USDC is a fully collateralized US dollar stablecoin.",
+  "explorer_url": "https://etherscan.io/token/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "icon_url": "https://assets.trustwalletapp.com/...",
+  "links": {
+    "twitter": "https://twitter.com/circle",
+    "telegram": "https://t.me/circle"
+  }
+}
+```

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: history
+description: Get transaction history and details for any wallet address — transfers, swaps, approvals, and contract interactions across all supported chains.
+---
+
+# Transaction History
+
+Query transaction history and get details for individual transactions.
+
+**Base URL:** `https://gateway.us.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+## Endpoints
+
+### Get Transaction History
+
+`GET /v1/txhub/txs`
+
+Get paginated transaction history for a wallet address.
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `address` | string | Yes | Wallet address |
+| `asset` | string | No | Filter by asset ID (e.g., `c60`, `c60_t0xA0b8...`) |
+| `chain` | string | No | Filter by chain key (e.g., `ethereum`, `bsc`) |
+| `from` | string | No | Start date (ISO 8601, e.g., `2026-01-01T00:00:00Z`) |
+| `to` | string | No | End date (ISO 8601) |
+| `limit` | number | No | Max results per page (default: 20) |
+| `tx_type` | string | No | Filter by type: `transfer`, `swap`, `approve`, `contract_call` |
+
+**Example request:**
+
+```
+GET /v1/txhub/txs?address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&chain=ethereum&limit=10
+```
+
+**Response:**
+
+```json
+{
+  "docs": [
+    {
+      "id": "tx-unique-id",
+      "hash": "0xabc123...",
+      "chain": "ethereum",
+      "type": "transfer",
+      "status": "completed",
+      "from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "to": "0xRecipient...",
+      "amount": "1000000000000000000",
+      "fee": "2100000000000000",
+      "date": "2026-02-27T14:30:00Z",
+      "metadata": {
+        "asset_id": "c60",
+        "symbol": "ETH",
+        "decimals": 18,
+        "name": "Ethereum"
+      }
+    }
+  ]
+}
+```
+
+**Transaction types:**
+
+| Type | Description |
+|------|-------------|
+| `transfer` | Token or native coin transfer |
+| `swap` | DEX swap |
+| `approve` | ERC-20 token approval |
+| `contract_call` | Generic smart contract interaction |
+
+**Status values:** `completed`, `pending`, `failed`
+
+---
+
+### Get Transaction Details
+
+`GET /v1/txhub/txs/{hash}`
+
+Get detailed information about a specific transaction by its hash.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `hash` | string | Yes | Transaction hash |
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `chain` | string | Yes | Chain key (e.g., `ethereum`, `bsc`, `solana`) |
+
+**Example request:**
+
+```
+GET /v1/txhub/txs/0xabc123def456...?chain=ethereum
+```
+
+**Response:**
+
+```json
+{
+  "id": "tx-unique-id",
+  "hash": "0xabc123def456...",
+  "chain": "ethereum",
+  "type": "transfer",
+  "status": "completed",
+  "from": "0xSender...",
+  "to": "0xRecipient...",
+  "amount": "1000000000000000000",
+  "fee": "2100000000000000",
+  "date": "2026-02-27T14:30:00Z",
+  "block_number": 19876543,
+  "nonce": 42,
+  "metadata": {
+    "asset_id": "c60",
+    "symbol": "ETH",
+    "decimals": 18,
+    "name": "Ethereum"
+  }
+}
+```

--- a/skills/market-data/SKILL.md
+++ b/skills/market-data/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: market-data
+description: Get real-time token prices (index from CoinMarketCap + CoinGecko), discover trending tokens across 16+ categories (AI, DeFi, memes, Layer 1, ecosystem-specific), with multi-timeframe price changes, market cap, volume, and supply data.
+---
+
+# Market Data
+
+Real-time token prices, trending asset discovery, and category-based rankings.
+
+## Endpoints
+
+### Get Token Prices (Index)
+
+`POST /v2/market/tickers`
+
+Get current USD prices for one or more tokens. Prices are aggregated from CoinMarketCap and CoinGecko, serving as an index price. This endpoint is public and requires **no authentication**.
+
+**Base URL:** `https://market.trustwallet.com`
+**Auth:** None
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `currency` | string | Yes | Target currency code (e.g., `"USD"`) |
+| `assets` | array | Yes | Array of asset ID strings (up to 50) |
+
+**Example — get ETH and USDC prices:**
+
+```json
+{
+  "currency": "USD",
+  "assets": ["c60", "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"]
+}
+```
+
+**Response:**
+
+```json
+{
+  "currency": "USD",
+  "tickers": [
+    {
+      "id": "c60",
+      "price": 3456.78,
+      "change_24h": 2.34,
+      "market_cap": 415000000000,
+      "volume_24h": 12000000000,
+      "total_supply": "120000000"
+    }
+  ]
+}
+```
+
+---
+
+### Get Trending / Listed Assets
+
+`GET /v1/assets/listings`
+
+Get trending or categorized token listings with rich market data — multi-timeframe price changes, market cap, volume, and supply.
+
+**Base URL:** `https://gateway.us.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `version` | number | Yes | API version, use `27` |
+| `currency` | string | Yes | Price currency (e.g., `USD`) |
+| `category_id` | string | No | Filter by category (see table below) |
+| `sort` | string | No | Sort order: `price24h`, `mcap`, `volume` |
+| `limit` | number | No | Max results (default: 20, max: 100) |
+| `networks` | string | No | Comma-separated SLIP-44 coin IDs |
+| `cursor` | string | No | Pagination cursor from previous response |
+| `use_pagination` | boolean | No | Enable cursor-based pagination |
+
+**Categories:**
+
+| `category_id` | Description | Default Sort |
+|---------------|-------------|-------------|
+| `trending` | Trending tokens (default) | — |
+| `ai` | AI and machine learning tokens | `price24h` |
+| `memes` | Meme coins | `price24h` |
+| `rwa-assets` | Real-world assets | `price24h` |
+| `x402` | x402 protocol tokens | `price24h` |
+| `layer_1` | Layer 1 blockchains | `mcap` |
+| `dex` | DEX tokens | `mcap` |
+| `defi-2` | DeFi protocols | `mcap` |
+| `eth-ecosystem` | Ethereum ecosystem | `mcap` |
+| `bnb-ecosystem` | BNB Chain ecosystem | `mcap` |
+| `solana-ecosystem` | Solana ecosystem | `mcap` |
+| `binance-launchpad` | Binance Launchpad projects | `mcap` |
+| `binance-launchpool` | Binance Launchpool projects | `mcap` |
+| `binance-megadrop` | Binance Megadrop projects | `mcap` |
+| `pump-fun` | PumpFun tokens | `volume` |
+| `bonk` | BONK ecosystem | `volume` |
+
+Categories are dynamic — use the listing-categories endpoint below to get the current list.
+
+**Example request:**
+
+```
+GET /v1/assets/listings?version=27&currency=USD&category_id=ai&sort=mcap&limit=20
+```
+
+**Response:**
+
+Each item in `docs[]` has three sub-objects: `asset`, `market`, and `price`.
+
+```json
+{
+  "docs": [
+    {
+      "asset": {
+        "asset_id": "c60_t0x...",
+        "name": "Token Name",
+        "symbol": "TKN",
+        "type": "token",
+        "decimals": 18,
+        "network": 60,
+        "icon_url": "https://assets.trustwalletapp.com/...",
+        "is_verified": true
+      },
+      "market": {
+        "market_cap": 1234567890,
+        "volume_24h": 123456789,
+        "circulating_supply": 500000000,
+        "total_supply": 1000000000,
+        "max_supply": 1000000000
+      },
+      "price": {
+        "price": 12.34,
+        "percent_change_1h": 0.5,
+        "percent_change_24h": 5.67,
+        "percent_change_7d": -2.1,
+        "percent_change_30d": 15.3,
+        "percent_change_60d": 22.0,
+        "percent_change_90d": 45.5
+      }
+    }
+  ],
+  "total": 150,
+  "cursor": "eyJsYXN0X2lkIjoiYWJjMTIzIn0="
+}
+```
+
+**Price change timeframes:** 1h, 24h, 7d, 30d, 60d, 90d — all returned in a single response.
+
+Use `cursor` from the response in the next request's `cursor` parameter to paginate.
+
+---
+
+### List Categories
+
+`GET /v1/assets/listing-categories`
+
+Get the current list of available asset listing categories. Categories are dynamic and may change over time.
+
+**Base URL:** `https://gateway.us.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `networks` | string | No | Comma-separated SLIP-44 coin IDs to filter categories by chain |
+
+**Example request:**
+
+```
+GET /v1/assets/listing-categories
+```
+
+**Response:**
+
+```json
+{
+  "docs": [
+    { "id": "trending", "name": "Trending" },
+    { "id": "ai", "name": "AI" },
+    { "id": "memes", "name": "Meme Coins" },
+    { "id": "rwa-assets", "name": "Real World Assets" },
+    { "id": "layer_1", "name": "Layer 1" },
+    { "id": "dex", "name": "DEX" },
+    { "id": "defi-2", "name": "DeFi" },
+    { "id": "eth-ecosystem", "name": "Ethereum Ecosystem" },
+    { "id": "bnb-ecosystem", "name": "BNB Ecosystem" },
+    { "id": "solana-ecosystem", "name": "Solana Ecosystem" }
+  ]
+}
+```

--- a/skills/onramp/SKILL.md
+++ b/skills/onramp/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: onramp
+description: Buy crypto with fiat (USD, EUR, GBP) or sell crypto for fiat — get quotes from multiple providers and checkout URLs to complete purchases.
+---
+
+# Fiat On-Ramp & Off-Ramp
+
+Buy crypto with fiat currency or sell crypto for fiat. Get quotes from multiple providers and redirect URLs for checkout.
+
+**Base URL:** `https://gateway.us.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+## Endpoints
+
+### Get Buy Quote
+
+`GET /v1/buycrypto/quote/{cryptoAsset}`
+
+Get quotes for buying crypto with fiat currency from available providers.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cryptoAsset` | string | Yes | Target asset ID (e.g., `c60` for ETH, `c60_t0xA0b8...` for ERC-20) |
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `amount` | number | Yes | Amount in fiat currency to spend |
+| `currency` | string | Yes | Fiat currency code (`USD`, `EUR`, `GBP`) |
+| `address` | string | Yes | Destination wallet address |
+
+**Example request:**
+
+```
+GET /v1/buycrypto/quote/c60?amount=100&currency=USD&address=0xYourAddress
+```
+
+**Response:**
+
+```json
+{
+  "quotes": [
+    {
+      "id": "quote-uuid-1",
+      "provider": {
+        "name": "MoonPay",
+        "logo_url": "https://..."
+      },
+      "digital_money": {
+        "amount": "0.028",
+        "currency": "ETH"
+      },
+      "fiat_money": {
+        "amount": "100.00",
+        "currency": "USD"
+      },
+      "payment_method": {
+        "payment_method": "credit_card"
+      }
+    },
+    {
+      "id": "quote-uuid-2",
+      "provider": {
+        "name": "Mercuryo"
+      },
+      "digital_money": {
+        "amount": "0.027",
+        "currency": "ETH"
+      },
+      "fiat_money": {
+        "amount": "100.00",
+        "currency": "USD"
+      },
+      "payment_method": {
+        "payment_method": "credit_card"
+      }
+    }
+  ]
+}
+```
+
+---
+
+### Get Buy Checkout URL
+
+`GET /v1/buycrypto/request/{quoteId}`
+
+Get a redirect URL for the user to complete the fiat-to-crypto purchase in their browser.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `quoteId` | string | Yes | Quote ID from the buy quote response |
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `address` | string | Yes | Destination wallet address |
+
+**Example request:**
+
+```
+GET /v1/buycrypto/request/quote-uuid-1?address=0xYourAddress
+```
+
+**Response:**
+
+```json
+{
+  "url": "https://buy.moonpay.com/...",
+  "redirect_url": "https://buy.moonpay.com/..."
+}
+```
+
+The `url` or `redirect_url` field contains the checkout page. Open it in a browser for the user to complete the purchase.
+
+---
+
+### Get Sell Quote
+
+`GET /v1/sellcrypto/quote/{cryptoAsset}`
+
+Get quotes for selling crypto to receive fiat currency.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cryptoAsset` | string | Yes | Asset ID to sell (e.g., `c60` for ETH) |
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `amount` | number | Yes | Amount of crypto to sell (in human-readable units) |
+| `currency` | string | Yes | Target fiat currency code (`USD`, `EUR`, `GBP`) |
+| `address` | string | Yes | Source wallet address |
+| `payment_method` | string | No | Payout method: `bank_transfer` (default), `card` |
+
+**Example request:**
+
+```
+GET /v1/sellcrypto/quote/c60?amount=0.5&currency=USD&address=0xYourAddress&payment_method=bank_transfer
+```
+
+**Response:**
+
+```json
+{
+  "quotes": [
+    {
+      "id": "sell-quote-uuid",
+      "provider": {
+        "name": "MoonPay"
+      },
+      "fiat_money": {
+        "amount": "1728.39",
+        "currency": "USD"
+      },
+      "digital_money": {
+        "amount": "0.5",
+        "currency": "ETH"
+      },
+      "fee": {
+        "fees": [
+          {
+            "amount": "25.00",
+            "currency": "USD",
+            "type": "network_fee"
+          }
+        ]
+      },
+      "is_recommended": true
+    }
+  ]
+}
+```
+
+---
+
+### Get Sell Checkout URL
+
+`GET /v1/sellcrypto/request/{quoteId}`
+
+Get a redirect URL for the user to complete the crypto-to-fiat sale.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `quoteId` | string | Yes | Quote ID from the sell quote response |
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `address` | string | Yes | Source wallet address |
+
+**Example request:**
+
+```
+GET /v1/sellcrypto/request/sell-quote-uuid?address=0xYourAddress
+```
+
+**Response:**
+
+```json
+{
+  "url": "https://sell.moonpay.com/...",
+  "redirect_url": "https://sell.moonpay.com/..."
+}
+```
+
+Open the URL in a browser for the user to complete the sale and receive fiat.

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: security
+description: Validate wallet addresses and check token risk — honeypot detection, audit status, freeze authority, and other security signals before interacting with a token or address.
+---
+
+# Security
+
+Validate addresses and analyze token risk before transacting.
+
+**Base URL:** `https://gateway.us.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+## Endpoints
+
+### Validate Address
+
+`GET /v1/validate`
+
+Validate a wallet address or transaction for security risks.
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `address` | string | Yes | Address to validate |
+| `asset_id` | string | No | Asset ID for context (e.g., `c60` for Ethereum) |
+| `type` | string | No | Validation type: `address`, `transaction` |
+
+**Example request:**
+
+```
+GET /v1/validate?address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&asset_id=c60&type=address
+```
+
+**Response:**
+
+```json
+{
+  "valid": true,
+  "result": "whitelist",
+  "details": {
+    "is_contract": false,
+    "is_sanctioned": false,
+    "risk_score": 0,
+    "labels": []
+  }
+}
+```
+
+**Result values:**
+
+| Value | Meaning |
+|-------|---------|
+| `whitelist` | Known safe address |
+| `neutral` | No risk signals |
+| `blacklist` | Known malicious address |
+| `unknown` | Not enough data |
+
+---
+
+### Check Token Risk
+
+`GET /v2/coinstatus/{assetId}`
+
+Check security and risk information for a token — honeypot detection, audit status, freeze authority, and more.
+
+**Path parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetId` | string | Yes | Asset ID (e.g., `c60_t0xA0b8...` for ERC-20, `c501` for SOL) |
+
+**Query parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `version` | string | No | API version (use `2`) |
+| `platform` | string | No | Platform identifier |
+| `include_security_info` | boolean | No | Include EVM security data (default: `true`) |
+| `include_solana_security_info` | boolean | No | Include Solana-specific security data (default: `true`) |
+
+**Example request:**
+
+```
+GET /v2/coinstatus/c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7?version=2&include_security_info=true
+```
+
+**Response:**
+
+```json
+{
+  "asset_id": "c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7",
+  "name": "Tether USD",
+  "symbol": "USDT",
+  "isActive": true,
+  "supportsSwap": true,
+  "securityInfo": {
+    "riskLevel": "low",
+    "isHoneypot": false,
+    "hasAudit": true,
+    "auditProvider": "OpenZeppelin",
+    "hasMintFunction": true,
+    "canTakeBackOwnership": false,
+    "isTradingCooldown": false,
+    "warnings": []
+  }
+}
+```
+
+For Solana tokens, the response includes `solanaSecurityInfo` instead:
+
+```json
+{
+  "solanaSecurityInfo": {
+    "riskLevel": "medium",
+    "hasFreezeAuthority": true,
+    "hasMintAuthority": true,
+    "isInitialized": true,
+    "warnings": ["Token has active freeze authority"]
+  }
+}
+```
+
+**Risk levels:** `low`, `medium`, `high`, `critical`, `unknown`
+
+**EVM security fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `riskLevel` | string | Overall risk level |
+| `isHoneypot` | boolean | Cannot sell after buying |
+| `hasAudit` | boolean | Smart contract has been audited |
+| `auditProvider` | string | Name of audit firm |
+| `hasMintFunction` | boolean | Token supply can be increased |
+| `canTakeBackOwnership` | boolean | Owner can reclaim ownership after renouncing |
+| `isTradingCooldown` | boolean | Trading restrictions after buy |
+| `warnings` | string[] | Human-readable risk warnings |
+
+**Solana security fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `riskLevel` | string | Overall risk level |
+| `hasFreezeAuthority` | boolean | Token accounts can be frozen |
+| `hasMintAuthority` | boolean | Supply can be increased |
+| `isInitialized` | boolean | Token program is initialized |
+| `warnings` | string[] | Human-readable risk warnings |

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: setup
+description: Trust Wallet API authentication — HMAC-SHA256 signing, API keys, base URLs, and the full list of 100+ supported chains. Read this first before using any other skill.
+---
+
+# Setup — Authentication & Configuration
+
+## Get API Keys
+
+Register at [portal.trustwallet.com](https://portal.trustwallet.com) to obtain:
+
+- **Access ID** — identifies your application
+- **HMAC Secret** — used to sign requests
+
+## Base URLs
+
+| Base URL | Auth | Used By |
+|----------|------|---------|
+| `https://gateway.us.trustwallet.com` | HMAC-SHA256 | Balance, assets, security, history, on/off-ramp, market listings |
+| `https://api.trustwallet.com` | HMAC-SHA256 | Swap quotes, step transactions, providers, domains (Amber API) |
+| `https://market.trustwallet.com` | None (public) | Token prices / market tickers (index from CMC + CoinGecko) |
+
+## HMAC-SHA256 Signing
+
+Every request to `gateway` and `api` base URLs must include four headers computed from the request.
+
+### Required Headers
+
+| Header | Value |
+|--------|-------|
+| `X-TW-CREDENTIAL` | Your Access ID |
+| `X-TW-NONCE` | Random UUID (v4), unique per request |
+| `X-TW-DATE` | Current UTC date in RFC 2822 format (e.g., `Thu, 27 Feb 2026 12:00:00 GMT`) |
+| `Authorization` | `HMAC-SHA256 Signature={base64_signature}` |
+| `Content-Type` | `application/json` |
+
+### Signature Algorithm
+
+1. **Build the plaintext** by joining these 6 fields with semicolons (`;`):
+
+```
+METHOD;PATH;SORTED_QUERY;ACCESS_ID;NONCE;DATE
+```
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `METHOD` | HTTP method, uppercase | `GET`, `POST` |
+| `PATH` | URL path without host or query string | `/v1/balance` |
+| `SORTED_QUERY` | Query parameters sorted alphabetically by key, joined with `&`. Empty string if no query params. Raw values (not URL-encoded). | `address=0xabc&coin=60` |
+| `ACCESS_ID` | Your Access ID | `870dfxaa...` |
+| `NONCE` | Same UUID from `X-TW-NONCE` header | `a1b2c3d4-e5f6-...` |
+| `DATE` | Same date from `X-TW-DATE` header | `Thu, 27 Feb 2026 12:00:00 GMT` |
+
+2. **Compute the HMAC-SHA256** of the plaintext using your HMAC Secret as the key.
+
+3. **Base64-encode** the result.
+
+4. Set the `Authorization` header to `HMAC-SHA256 Signature={base64_result}`.
+
+### Pseudocode
+
+```
+nonce    = random_uuid_v4()
+date     = utc_date_rfc2822()
+
+// Sort query params alphabetically by key
+sorted_query = sort_by_key(query_params).map(k + "=" + v).join("&")
+
+plaintext = METHOD + ";" + path + ";" + sorted_query + ";" + access_id + ";" + nonce + ";" + date
+
+signature = base64(hmac_sha256(hmac_secret, plaintext))
+
+headers = {
+  "X-TW-CREDENTIAL": access_id,
+  "X-TW-NONCE":      nonce,
+  "X-TW-DATE":       date,
+  "Authorization":   "HMAC-SHA256 Signature=" + signature,
+  "Content-Type":    "application/json"
+}
+```
+
+### Example (JavaScript / Node.js)
+
+```javascript
+import { createHmac, randomUUID } from 'node:crypto';
+
+function signRequest(method, path, query, accessId, hmacSecret) {
+  const date = new Date().toUTCString();
+  const nonce = randomUUID();
+
+  // Sort query params by key (raw values, not URL-encoded)
+  const sortedQuery = query
+    ? [...new URLSearchParams(query).entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&')
+    : '';
+
+  const plaintext = [method.toUpperCase(), path, sortedQuery, accessId, nonce, date].join(';');
+  const signature = createHmac('sha256', hmacSecret).update(plaintext).digest('base64');
+
+  return {
+    'X-TW-CREDENTIAL': accessId,
+    'X-TW-NONCE': nonce,
+    'X-TW-DATE': date,
+    'Authorization': `HMAC-SHA256 Signature=${signature}`,
+    'Content-Type': 'application/json',
+  };
+}
+```
+
+### Example (Python)
+
+```python
+import hmac, hashlib, base64, uuid
+from datetime import datetime, timezone
+from urllib.parse import parse_qs
+
+def sign_request(method, path, query, access_id, hmac_secret):
+    date = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
+    nonce = str(uuid.uuid4())
+
+    # Sort query params by key
+    if query:
+        params = parse_qs(query, keep_blank_values=True)
+        sorted_query = '&'.join(
+            f'{k}={v[0]}' for k, v in sorted(params.items())
+        )
+    else:
+        sorted_query = ''
+
+    plaintext = ';'.join([method.upper(), path, sorted_query, access_id, nonce, date])
+    signature = base64.b64encode(
+        hmac.new(hmac_secret.encode(), plaintext.encode(), hashlib.sha256).digest()
+    ).decode()
+
+    return {
+        'X-TW-CREDENTIAL': access_id,
+        'X-TW-NONCE': nonce,
+        'X-TW-DATE': date,
+        'Authorization': f'HMAC-SHA256 Signature={signature}',
+        'Content-Type': 'application/json',
+    }
+```
+
+## CLI Wallet Password
+
+MCP tools that access the agent wallet (`get_address`, `wallet_balance`, `transfer_token`, `swap`, etc.) require a `password` parameter to decrypt the wallet mnemonic stored at `~/.tw-agent/wallet.json`.
+
+The password is resolved in this priority order:
+
+1. **`password` parameter** — passed directly in the tool call
+2. **`TWAK_WALLET_PASSWORD` environment variable** — for CI / headless environments
+3. **OS Keychain** — stored automatically when the wallet is created (service: `tw-agent`, account: `wallet`)
+
+### Creating a wallet
+
+```bash
+tw-agent wallet create --password <your-password>
+```
+
+The password is saved to the OS keychain by default. Use `--no-keychain` to skip keychain storage.
+
+### Encryption
+
+The wallet mnemonic is encrypted with **AES-256-GCM** using PBKDF2 key derivation (600,000 iterations, SHA-256). The plaintext mnemonic is never stored on disk.
+
+## Asset ID Format
+
+Trust Wallet uses a compact asset ID across all APIs:
+
+- **Native coin**: `c{coinId}` — e.g., `c60` (ETH), `c714` (BNB), `c501` (SOL)
+- **Token**: `c{coinId}_t{contractAddress}` — e.g., `c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` (USDC on Ethereum)
+
+The `coinId` follows the [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) standard.
+
+## Supported Chains
+
+Trust Wallet supports 100+ chains. Below is the complete list grouped by type.
+
+### EVM Chains
+
+| Chain | Coin ID | Symbol | Chain ID |
+|-------|---------|--------|----------|
+| Ethereum | 60 | ETH | 1 |
+| BNB Smart Chain (BSC) | 714 | BNB | 56 |
+| Polygon | 966 | MATIC | 137 |
+| Avalanche C-Chain | 10009000 | AVAX | 43114 |
+| Arbitrum | 10042221 | ETH | 42161 |
+| Optimism | 10000070 | ETH | 10 |
+| Base | 10008453 | ETH | 8453 |
+| Fantom | 10000250 | FTM | 250 |
+| Sonic | — | S | — |
+| Linea | — | ETH | 59144 |
+| zkSync Era | — | ETH | 324 |
+| Scroll | — | ETH | 534352 |
+| Blast | — | ETH | 81457 |
+| Manta Pacific | — | ETH | 169 |
+| Mantle | — | MNT | 5000 |
+| Polygon zkEVM | — | ETH | 1101 |
+| Cronos | — | CRO | 25 |
+| Gnosis (xDai) | — | xDAI | 100 |
+| Celo | — | CELO | 42220 |
+| Aurora | — | ETH | 1313161554 |
+| Moonbeam | — | GLMR | 1284 |
+| Moonriver | — | MOVR | 1285 |
+| Boba | — | ETH | 288 |
+| Metis | — | METIS | 1088 |
+| KuCoin Community Chain | — | KCS | 321 |
+| Klaytn (Kaia) | — | KLAY | 8217 |
+| IoTeX (EVM) | — | IOTX | 4689 |
+| Ronin | — | RON | 2020 |
+| Viction | — | VIC | 88 |
+| Neon | — | NEON | 245022934 |
+| opBNB | — | BNB | 204 |
+| Merlin | — | BTC | 4200 |
+| Acala (EVM) | — | ACA | 787 |
+| Conflux eSpace | — | CFX | 1030 |
+| Kava (EVM) | — | KAVA | 2222 |
+| ZetaChain (EVM) | — | ZETA | 7000 |
+| BounceBit | — | BB | — |
+| zkLink Nova | — | ETH | — |
+| Ethereum Classic | — | ETC | 61 |
+| ThunderCore | — | TT | 108 |
+| Wanchain | — | WAN | 888 |
+| GoChain | — | GO | 60 |
+| Callisto | — | CLO | 820 |
+| Harmony | — | ONE | — |
+| Evmos (EVM) | — | EVMOS | 9001 |
+| Monad | — | MON | — |
+| MegaETH | — | ETH | — |
+| Plasma | — | — | — |
+
+### Solana
+
+| Chain | Coin ID | Symbol |
+|-------|---------|--------|
+| Solana | 501 | SOL |
+
+### Bitcoin & UTXO Chains
+
+| Chain | Coin ID | Symbol |
+|-------|---------|--------|
+| Bitcoin | 0 | BTC |
+| Litecoin | 2 | LTC |
+| Dogecoin | 3 | DOGE |
+| Bitcoin Cash | 145 | BCH |
+| Zcash | 133 | ZEC |
+| Dash | 5 | DASH |
+| Ravencoin | 175 | RVN |
+| DigiByte | 20 | DGB |
+| Decred | 42 | DCR |
+| Qtum | 2301 | QTUM |
+| Groestlcoin | 17 | GRS |
+| Viacoin | 14 | VIA |
+| Firo | 136 | FIRO |
+| Flux (Zelcash) | 19167 | FLUX |
+
+### Cosmos Ecosystem
+
+| Chain | Coin ID | Symbol |
+|-------|---------|--------|
+| Cosmos Hub | 118 | ATOM |
+| Osmosis | 10000118 | OSMO |
+| THORChain | 931 | RUNE |
+| Kava | 459 | KAVA |
+| Terra | 330 | LUNA |
+| Injective | — | INJ |
+| Sei | — | SEI |
+| Stride | — | STRD |
+| Axelar | — | AXL |
+| Neutron | — | NTRN |
+| Akash | — | AKT |
+| Agoric | — | BLD |
+| Juno | — | JUNO |
+| Stargaze | — | STARS |
+| Crypto.org | — | CRO |
+| Evmos (Cosmos) | — | EVMOS |
+| Greenfield | — | BNB |
+| ZetaChain (Cosmos) | — | ZETA |
+
+### Other L1 Chains
+
+| Chain | Coin ID | Symbol |
+|-------|---------|--------|
+| Tron | 195 | TRX |
+| Aptos | 637 | APT |
+| TON | 607 | TON |
+| Sui | 784 | SUI |
+| NEAR | 397 | NEAR |
+| Solana | 501 | SOL |
+| Polkadot | 354 | DOT |
+| Kusama | 434 | KSM |
+| Cardano | 1815 | ADA |
+| XRP Ledger | 144 | XRP |
+| Stellar | 148 | XLM |
+| Algorand | 283 | ALGO |
+| Tezos | 1729 | XTZ |
+| Internet Computer | 223 | ICP |
+| MultiversX | 508 | EGLD |
+| VeChain | 818 | VET |
+| Filecoin | 461 | FIL |
+| Zilliqa | 313 | ZIL |
+| ICON | 74 | ICX |
+| Waves | 5741564 | WAVES |
+| Nano | 165 | XNO |
+| Ontology | 1024 | ONT |
+| Theta | 500 | THETA |
+| Nebulas | 2718 | NAS |
+| Aion | 425 | AION |
+| Aeternity | 457 | AE |
+| IoTeX | 304 | IOTX |
+| FIO | 235 | FIO |
+| Nimiq | 242 | NIM |
+
+## Chain Key vs Chain ID
+
+When using domain-based endpoints (e.g., swap), use the **chain key** (the identifier used in API routing), not the internal chain ID. For most chains they are the same, but notably:
+
+| Chain Key (use this) | Internal Chain ID |
+|----------------------|-------------------|
+| `bsc` | `smartchain` |
+| `ethereum` | `ethereum` |
+| `polygon` | `polygon` |
+| `solana` | `solana` |

--- a/skills/swap-quote/SKILL.md
+++ b/skills/swap-quote/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: swap-quote
+description: Get swap quotes and transaction data for token swaps across any chain — same-chain and cross-chain via the Amber aggregator with 10+ DEX and bridge providers including 1inch, Jupiter, KyberSwap, THORChain, Stargate, and more.
+---
+
+# Swap Quotes
+
+Get quotes and transaction data for same-chain and cross-chain token swaps via the Amber aggregator.
+
+**Base URL:** `https://api.trustwallet.com`
+**Auth:** HMAC-SHA256 (see [setup](../setup/SKILL.md))
+
+## Providers
+
+The Amber aggregator routes through 10+ DEX and bridge providers plus its own LiquidMesh routing engine:
+
+**DEX providers (same-chain):**
+
+| Provider | Chains |
+|----------|--------|
+| 1inch | Ethereum, BSC, Polygon, Arbitrum, Optimism, Avalanche, Base, zkSync |
+| KyberSwap | Ethereum, BSC, Polygon, Arbitrum, Optimism, Avalanche, Base, Linea, zkSync |
+| 0x | Ethereum, BSC, Polygon, Arbitrum, Fantom |
+| Jupiter | Solana |
+| THORChain | Bitcoin, Litecoin, Dogecoin, Bitcoin Cash |
+
+**Bridge providers (cross-chain):**
+
+| Provider | Description |
+|----------|-------------|
+| Stargate Finance | LayerZero-based bridge |
+| Synapse Protocol | Cross-chain messaging + bridge |
+| Squid Router | Axelar-based cross-chain |
+| Rango Exchange | Multi-bridge aggregator |
+| SWFT Bridgers | Tron, TON, XRP bridging |
+
+**Internal:**
+
+| Provider | Description |
+|----------|-------------|
+| LiquidMesh | Amber's internal liquidity aggregation engine |
+
+## Concepts
+
+### Domain IDs
+
+The Amber API uses **domain IDs** to identify chains. Use the domains endpoint to get the full list, or refer to common ones:
+
+| Domain ID | Chain |
+|-----------|-------|
+| `ethereum` | Ethereum |
+| `bsc` | BNB Smart Chain |
+| `polygon` | Polygon |
+| `arbitrum` | Arbitrum |
+| `optimism` | Optimism |
+| `base` | Base |
+| `avalanche` | Avalanche |
+| `solana` | Solana |
+| `bitcoin` | Bitcoin |
+| `tron` | Tron |
+
+### Token Addresses
+
+- **EVM native tokens**: Use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+- **Solana native (SOL)**: Use `So11111111111111111111111111111111111111112` (wrapped SOL mint)
+- **All other tokens**: Use the contract/mint address
+
+## Endpoints
+
+### List Supported Domains
+
+`GET /amber-api/v1/domains`
+
+Get the list of chains (domains) supported by the Amber aggregator, along with which DEX providers are available on each chain.
+
+**Example request:**
+
+```
+GET /amber-api/v1/domains
+```
+
+**Response:**
+
+```json
+[
+  {
+    "id": "ethereum",
+    "name": "Ethereum",
+    "coinId": 60,
+    "dex": ["rango", "1inch", "kyber", "zeroex"]
+  },
+  {
+    "id": "solana",
+    "name": "Solana",
+    "coinId": 501,
+    "dex": ["jupiter", "rango"]
+  },
+  {
+    "id": "bitcoin",
+    "name": "Bitcoin",
+    "coinId": 0,
+    "dex": ["thorchain"]
+  }
+]
+```
+
+---
+
+### List Providers
+
+`GET /amber-api/v1/providers`
+
+Get the list of all DEX and bridge providers supported by the Amber aggregator.
+
+**Example request:**
+
+```
+GET /amber-api/v1/providers
+```
+
+**Response:**
+
+```json
+{
+  "dex": [
+    { "id": "1inch", "name": "1inch Network", "rank": 5 },
+    { "id": "kyber", "name": "KyberSwap", "rank": 3 },
+    { "id": "zeroex", "name": "0x", "rank": 4 },
+    { "id": "jupiter", "name": "Jupiter", "rank": 4 },
+    { "id": "thorchain", "name": "THORChain", "rank": 3 }
+  ],
+  "bridge": [
+    { "id": "stargate", "name": "Stargate Finance", "rank": 4 },
+    { "id": "synapse", "name": "Synapse Protocol", "rank": 3 },
+    { "id": "squid", "name": "Squid Router", "rank": 3 },
+    { "id": "rango", "name": "Rango Exchange", "rank": 3 },
+    { "id": "swft", "name": "SWFT Bridgers", "rank": 2 }
+  ]
+}
+```
+
+You can use provider IDs in the route request to filter preferred or ignored providers.
+
+---
+
+### Get Swap Quote
+
+`POST /amber-api/v1/route`
+
+Get swap routes with price quotes. Returns one or more routes ranked by output amount.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fromAsset` | string | Yes | Source token address |
+| `fromAddress` | string | Yes | Sender wallet address |
+| `fromDomain` | string | Yes | Source chain domain ID |
+| `amount` | string | Yes | Amount in smallest unit (wei, lamports, etc.) |
+| `toAsset` | string | Yes | Destination token address |
+| `toAddress` | string | No | Receiver address (defaults to `fromAddress`) |
+| `toDomain` | string | Yes | Destination chain domain ID |
+| `slippage` | string | No | Slippage tolerance in percent (default: `"1"`) |
+| `sortBy` | string | No | Sort routes by `"outcome"` (default) or `"fee"` |
+| `contractCall` | boolean | No | Set `false` for EOA wallets (default: `false`) |
+| `preferredProviders` | string[] | No | Provider IDs to prefer (e.g., `["1inch", "jupiter"]`) |
+| `ignoredProviders` | string[] | No | Provider IDs to exclude |
+| `thorchain` | object | No | `{ "streaming": true }` to enable THORChain streaming swaps |
+
+**Example — swap 0.1 ETH to USDC on Base:**
+
+```json
+{
+  "fromAsset": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+  "fromAddress": "0xYourAddress",
+  "fromDomain": "base",
+  "amount": "100000000000000000",
+  "toAsset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "toAddress": "0xYourAddress",
+  "toDomain": "base",
+  "slippage": "1",
+  "sortBy": "outcome",
+  "contractCall": false
+}
+```
+
+**Response:**
+
+```json
+{
+  "routes": [
+    {
+      "id": "route-uuid",
+      "expirationDate": "2026-03-03T12:05:00Z",
+      "steps": [
+        {
+          "id": "step-uuid",
+          "type": "STEP_TYPE_SWAP",
+          "from": {
+            "asset": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+            "address": "0xYourAddress",
+            "amount": "100000000000000000"
+          },
+          "to": {
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "address": "0xYourAddress",
+            "amount": "234560000",
+            "minAmountOut": "232214400"
+          },
+          "slippage": "1",
+          "priceImpact": "0.01",
+          "provider": {
+            "id": "1inch",
+            "name": "1inch Network"
+          },
+          "networkFee": {
+            "amount": "0.0001",
+            "asset": "ETH"
+          }
+        }
+      ],
+      "warnings": []
+    }
+  ],
+  "config": {
+    "refreshInterval": "60"
+  }
+}
+```
+
+**Step types:** `STEP_TYPE_SWAP`, `STEP_TYPE_BRIDGE`, `STEP_TYPE_WRAP`, `STEP_TYPE_UNWRAP`
+
+---
+
+### Get Step Transaction
+
+`POST /amber-api/v1/route/step`
+
+Get the executable transaction data for a specific swap step. Call this for each step in a route.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `stepId` | string | Yes | Step ID from the route response |
+
+```json
+{
+  "stepId": "step-uuid"
+}
+```
+
+**Response:**
+
+```json
+{
+  "stepId": "step-uuid",
+  "transaction": {
+    "domainId": "base",
+    "type": "swap",
+    "evmTx": {
+      "to": "0xRouterContract",
+      "value": "100000000000000000",
+      "data": "0xcalldata...",
+      "gasLimit": "250000"
+    }
+  },
+  "approve": {
+    "to": "0xTokenContract",
+    "value": "0",
+    "data": "0xapproveCalldata...",
+    "gasLimit": "60000"
+  },
+  "revokeApproval": null
+}
+```
+
+**Transaction fields:**
+
+| Field | Description |
+|-------|-------------|
+| `transaction` | The main swap transaction |
+| `approve` | ERC-20 approval transaction (if spending a token, not native) |
+| `revokeApproval` | Revoke previous unlimited approval (if needed for security) |
+
+For non-EVM chains (e.g., Solana), the `transaction` field contains a `data` string (base64 encoded raw transaction) instead of `evmTx`.
+
+## Execution Flow
+
+1. **Get quote** — `POST /amber-api/v1/route` to get routes
+2. **Select route** — pick the best route (first is sorted by `sortBy`)
+3. **Get transactions** — for each step, call `POST /amber-api/v1/route/step`
+4. **Execute in order:**
+   - If `revokeApproval` exists → send it first, wait for confirmation
+   - If `approve` exists → send approval, wait for confirmation
+   - Send the main `transaction`
+
+Cross-chain swaps may have multiple steps (e.g., swap + bridge). Execute each step's transactions sequentially.

--- a/skills/transfer/SKILL.md
+++ b/skills/transfer/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: transfer
+description: Transfer tokens and native assets to any address with ENS name resolution, manage ERC-20 approvals, and check token allowances. Use this whenever someone wants to send crypto, transfer tokens, approve a spender, check allowances, or send to an ENS name like vitalik.eth.
+---
+
+# Transfers & Approvals
+
+Transfer native assets and tokens to any address (including ENS names), manage ERC-20 token approvals, and check allowances.
+
+## Actions
+
+### Transfer Token
+
+Transfer a native asset or token to a destination address. Supports ENS names (e.g., `vitalik.eth`) which are automatically resolved via the Trust Wallet naming service.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `assetId` | string | Yes | Token ID (e.g., `c60` for ETH, `c60_t0xA0b86991...` for USDC on Ethereum) |
+| `to` | string | Yes | Destination address or ENS name |
+| `amount` | string | Yes | Amount in smallest unit (wei, lamports, satoshis) |
+| `memo` | string | No | Optional memo/note |
+
+**Example — send 0.001 ETH to an ENS name:**
+
+```json
+{
+  "assetId": "c60",
+  "to": "vitalik.eth",
+  "amount": "1000000000000000"
+}
+```
+
+**Response:**
+
+```json
+{
+  "hash": "0x2a37fcca21541021f3b4efd954992bcb9050d7a42bafbad309c6947ffdcebf4b",
+  "chainKey": "ethereum",
+  "to": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+  "resolvedFrom": "vitalik.eth"
+}
+```
+
+The `resolvedFrom` field appears only when ENS resolution was performed.
+
+### Asset ID Reference
+
+| Asset | Asset ID |
+|-------|----------|
+| ETH (native) | `c60` |
+| BNB (native) | `c714` |
+| SOL (native) | `c501` |
+| BTC (native) | `c0` |
+| USDC on Ethereum | `c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| USDT on Ethereum | `c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7` |
+| USDT on BSC | `c714_t0x55d398326f99059fF775485246999027B3197955` |
+
+See [setup](../setup/SKILL.md) for the full asset ID format and chain list.
+
+---
+
+### Approve Token
+
+Approve a spender to use tokens on your behalf (ERC-20 `approve`). Required before swapping ERC-20 tokens through a DEX router.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `assetId` | string | Yes | Token ID to approve (must be a token, not native) |
+| `spender` | string | Yes | Spender contract address |
+| `amount` | string | Yes | Amount to approve in smallest unit, or `"unlimited"` |
+
+**Example — approve USDC for a DEX router:**
+
+```json
+{
+  "assetId": "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "spender": "0x3d90f66B534Dd8482b181e24655A9e8265316BE9",
+  "amount": "unlimited"
+}
+```
+
+**Response:**
+
+```json
+{
+  "hash": "0xabc123...",
+  "chainKey": "ethereum"
+}
+```
+
+Using `"unlimited"` sets the max uint256 allowance. For better security, approve only the amount needed.
+
+---
+
+### Check Allowance
+
+Check how much of a token a spender is approved to use.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `assetId` | string | Yes | Token ID to check |
+| `owner` | string | Yes | Token owner address |
+| `spender` | string | Yes | Spender address to check |
+
+**Response:**
+
+```json
+{
+  "assetId": "c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "owner": "0xD4BC...",
+  "spender": "0x3d90...",
+  "allowance": "1000000000"
+}
+```
+
+Allowance is in the token's smallest unit. For USDC (6 decimals), `1000000000` = 1,000 USDC.
+
+## Amount Conversion
+
+Balances and amounts are always in the smallest unit:
+
+| Token | Decimals | 1.0 in smallest unit |
+|-------|----------|---------------------|
+| ETH | 18 | `1000000000000000000` |
+| BNB | 18 | `1000000000000000000` |
+| USDC | 6 | `1000000` |
+| USDT | 6 | `1000000` |
+| SOL | 9 | `1000000000` |
+| BTC | 8 | `100000000` |

--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: wallet
+description: Manage agent wallets and WalletConnect sessions — create wallets, get addresses across 25+ chains, check balances, and connect external wallets via QR code. Use this whenever someone asks about their wallet address, wants to create a new wallet, check connection status, or connect an external wallet.
+---
+
+# Wallet Management
+
+Create and manage agent wallets, retrieve addresses across chains, and connect external wallets via WalletConnect.
+
+The agent wallet is an HD wallet derived from an encrypted mnemonic stored at `~/.tw-agent/wallet.json`. It supports 25+ chains from a single seed phrase.
+
+## Password Resolution
+
+MCP tools that access the agent wallet require a password to decrypt the mnemonic. The password is resolved in this order:
+
+1. **`password` parameter** — passed directly in the tool call
+2. **`TWAK_WALLET_PASSWORD` environment variable** — for CI / headless environments
+3. **OS Keychain** — stored automatically when the wallet is created (service: `tw-agent`, account: `wallet`)
+
+## Encryption
+
+The mnemonic is encrypted with **AES-256-GCM** using PBKDF2 key derivation (600,000 iterations, SHA-256). The plaintext mnemonic is never stored on disk.
+
+## Actions
+
+### Create Wallet
+
+Create a new agent wallet with a generated mnemonic.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `password` | string | Yes | Password to encrypt the wallet (min 8 characters) |
+
+**Response:**
+
+```json
+{
+  "message": "Agent wallet created successfully",
+  "addresses": [
+    { "address": "0xABC...", "chainId": "ethereum" },
+    { "address": "0xABC...", "chainId": "bsc" },
+    { "address": "9cwz...", "chainId": "solana" }
+  ]
+}
+```
+
+The password is saved to the OS keychain by default. Use `--no-keychain` when creating via CLI to skip keychain storage.
+
+---
+
+### Get Address
+
+Get the agent wallet address for a specific chain.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `chainKey` | string | Yes | Chain key (e.g., `ethereum`, `bsc`, `solana`, `bitcoin`) |
+| `password` | string | Yes | Wallet password |
+
+**Response:**
+
+```json
+{
+  "chainKey": "ethereum",
+  "address": "0xD4BC2539F3127925614FEdE66B6f10E2a466bb9B"
+}
+```
+
+---
+
+### List Addresses
+
+List all agent wallet addresses across all supported chains.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `password` | string | Yes | Wallet password |
+
+**Response:**
+
+```json
+{
+  "addresses": [
+    { "address": "0xD4BC...", "chainId": "ethereum" },
+    { "address": "0xD4BC...", "chainId": "bsc" },
+    { "address": "9cwz...", "chainId": "solana" },
+    { "address": "bc1q...", "chainId": "bitcoin" },
+    { "address": "TBF3...", "chainId": "tron" }
+  ],
+  "count": 25
+}
+```
+
+---
+
+### Wallet Balance
+
+Get the native token balance for the agent wallet on a specific chain.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `chainKey` | string | Yes | Chain key (e.g., `ethereum`, `bsc`) |
+| `password` | string | Yes | Wallet password |
+
+**Response:**
+
+```json
+{
+  "chainKey": "ethereum",
+  "address": "0xD4BC2539F3127925614FEdE66B6f10E2a466bb9B",
+  "balance": {
+    "available": "3126775296453912",
+    "total": "3126775296453912"
+  }
+}
+```
+
+Balance is in the smallest unit (wei for ETH, lamports for SOL, satoshis for BTC). Divide by `10^decimals` for human-readable amounts.
+
+---
+
+### Get Wallet Status
+
+Check connection status for both agent wallet and WalletConnect.
+
+**Parameters:** None
+
+**Response:**
+
+```json
+{
+  "agent": {
+    "connected": true,
+    "addresses": [
+      { "address": "0xD4BC...", "chainId": "ethereum" },
+      { "address": "9cwz...", "chainId": "solana" }
+    ]
+  }
+}
+```
+
+---
+
+### Connect Wallet (WalletConnect)
+
+Connect an external wallet via WalletConnect. Returns a QR code URI and deep links.
+
+**Parameters:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `chains` | string[] | No | Chains to connect (default: `["eip155:1"]`) |
+
+Requires `WALLETCONNECT_PROJECT_ID` environment variable and `--walletconnect` flag when starting the MCP server.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "uri": "wc:abc123...",
+  "deepLinks": {
+    "native": "trust://wc?uri=...",
+    "universal": "https://link.trustwallet.com/wc?uri=..."
+  },
+  "qrCode": {
+    "terminal": "▄▄▄▄▄...",
+    "imageUrl": "https://..."
+  },
+  "expiresAt": 1709500000
+}
+```
+
+## Supported Chains
+
+The agent wallet derives addresses for 25+ chains including all EVM chains, Solana, Bitcoin, Litecoin, Dogecoin, Tron, Cosmos, NEAR, Aptos, TON, and Sui. See [setup](../setup/SKILL.md) for the complete chain list.


### PR DESCRIPTION
## Summary
- Add 11 new agent API skills covering 35 MCP actions for Trust Wallet's AI agent
- Skills: setup, balance, wallet, transfer, swap-quote, history, market-data, security, alerts, automations, onramp
- Update README with full skills table, installation instructions, and workflow diagram

## Skills added

| Skill | Actions | Description |
|-------|---------|-------------|
| setup | — | API auth, HMAC signing, asset ID format, 100+ chains |
| balance | 4 | Wallet balance, token holdings, search, asset info |
| wallet | 6 | Create/manage wallets, addresses, WalletConnect |
| transfer | 3 | Token transfers (ENS), approvals, allowance checks |
| swap-quote | 2 | Same-chain and cross-chain swaps via Amber aggregator |
| history | 2 | Transaction history and details |
| market-data | 3 | Token prices, trending tokens across 16+ categories |
| security | 2 | Address validation, token risk (honeypot, audit, freeze) |
| alerts | 4 | Price alerts — create, list, check, delete |
| automations | 4 | DCA and limit order automations |
| onramp | 5 | Buy/sell crypto with fiat, quotes from multiple providers |

## Test plan
- [ ] Verify each SKILL.md loads correctly in Claude Code via `/skill`
- [ ] Test MCP tool invocations match documented schemas
- [ ] Confirm setup skill chain table matches current API support