### PR TITLE
docs(wallet): add DCA & limit order automation skill

### DIFF
--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trust-wallet-cli
-description: Trust Wallet CLI (`twak`) — install, create wallets, check balances, send tokens, swap, view history, set price alerts, manage ERC-20 approvals, check token risk, browse trending/DApps, and run x402 micropayments. Use whenever the user wants to use the twak CLI, manage a crypto wallet from the terminal, send or swap tokens via command line, check portfolio, create price alerts, approve ERC-20 spenders, or interact with Trust Wallet from a shell. Also covers MCP server setup for AI agents.
+description: Trust Wallet CLI (`twak`) — install, create wallets, check balances, send tokens, swap, view history, set price alerts, DCA automations, limit orders, manage ERC-20 approvals, check token risk, browse trending/DApps, and run x402 micropayments. Use whenever the user wants to use the twak CLI, manage a crypto wallet from the terminal, send or swap tokens via command line, check portfolio, create price alerts, set up DCA, create limit orders, approve ERC-20 spenders, or interact with Trust Wallet from a shell. Also covers MCP server setup for AI agents.
 ---
 
 # Trust Wallet CLI (`twak`)
@@ -25,6 +25,7 @@ Read the reference that matches the user's task:
 | Prices, trending, DApps | `references/market.md` | "price of", "trending tokens", "dapps" |
 | Transaction history | `references/history.md` | "tx history", "transaction details" |
 | Price alerts | `references/alerts.md` | "alert when ETH", "price alert", "notify me" |
+| DCA & limit orders | `references/automations.md` | "DCA", "dollar cost average", "limit order", "recurring swap", "buy when price" |
 | ERC-20 approve/revoke | `references/erc20.md` | "approve spender", "check allowance", "revoke" |
 | Token risk checks | `references/token-risk.md` | "is this token safe", "honeypot check", "audit status" |
 | x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API" |

--- a/skills/wallet/references/alerts.md
+++ b/skills/wallet/references/alerts.md
@@ -5,11 +5,13 @@ Set up price alerts that trigger when tokens reach target prices. Alerts are sto
 
 ## Create an Alert
 
+Accepts token symbols (auto-detects chain for native tokens) or asset IDs:
+
 ```bash
+twak alert create --token ETH --above 5000 --json
+twak alert create --token BTC --below 50000 --json
+twak alert create --token USDC --chain bsc --above 1.1 --json
 twak alert create --token c60 --chain ethereum --below 2000 --json
-twak alert create --token c60 --chain ethereum --above 5000 --json
-twak alert create --token c20000714 --chain bsc --above 500 --json
-twak alert create --token c501 --chain solana --below 100 --json
 ```
 
 ## List Alerts
@@ -35,12 +37,15 @@ twak alert delete <alertId>
 
 ## Continuous Monitoring
 
-Use `twak watch` to continuously poll and check alerts:
+Use `twak watch` to continuously poll alerts and execute DCA/limit order automations:
 
 ```bash
 twak watch                    # polls every 60s
 twak watch --interval 5m     # custom interval
+twak watch --dry-run         # check conditions without executing
 ```
+
+See `references/automations.md` for DCA and limit order setup.
 
 ## Token IDs
 

--- a/skills/wallet/references/automations.md
+++ b/skills/wallet/references/automations.md
@@ -5,48 +5,52 @@ Create recurring swaps (DCA) or conditional one-time swaps (limit orders) that e
 
 ## Create a DCA Automation
 
-Dollar-cost averaging — swap a fixed amount on a recurring schedule.
+Dollar-cost averaging — swap a fixed amount of the source token (`--from`) on a recurring schedule. `--amount` is always denominated in the source token.
 
 ```bash
 twak automate add \
-  --type dca \
-  --from-token BNB --to-token USDC \
+  --from BNB --to USDC \
   --chain bsc \
   --amount 0.01 \
   --interval 24h \
   --json
 
 twak automate add \
-  --type dca \
-  --from-token ETH --to-token USDC \
+  --from ETH --to USDC \
   --chain ethereum \
   --amount 0.005 \
   --interval 7d \
   --json
 ```
 
-Intervals: `1h`, `6h`, `12h`, `24h`, `7d`, `30d`.
+Intervals: `30s`, `1m`, `5m`, `1h`, `6h`, `12h`, `24h`, `7d`, `30d` (minimum 5s).
 
 ## Create a Limit Order
 
-One-time swap that executes when price reaches a target.
+One-time swap that executes when the destination token's USD spot price meets a condition.
+
+`--condition` values:
+- `below` (default) — executes when price <= target (buy the dip)
+- `above` — executes when price >= target (take profit)
+
+`--price` is the target USD price of the destination token (`--to`). `--amount` is in the source token (`--from`).
 
 ```bash
+# Buy ETH when it drops below $1800 (spend 100 USDC)
 twak automate add \
-  --type limit \
-  --from-token USDC --to-token ETH \
+  --from USDC --to ETH \
   --chain ethereum \
   --amount 100 \
-  --target-price 1800 \
+  --price 1800 \
   --json
 
+# Sell BNB for USDT when BNB rises above $700
 twak automate add \
-  --type limit \
-  --from-token USDC --to-token BNB \
+  --from BNB --to USDT \
   --chain bsc \
-  --amount 50 \
-  --target-price 400 \
-  --condition below \
+  --amount 0.1 \
+  --price 700 \
+  --condition above \
   --json
 ```
 

--- a/skills/wallet/references/automations.md
+++ b/skills/wallet/references/automations.md
@@ -1,0 +1,86 @@
+
+# DCA & Limit Order Automations
+
+Create recurring swaps (DCA) or conditional one-time swaps (limit orders) that execute automatically via `twak watch`.
+
+## Create a DCA Automation
+
+Dollar-cost averaging — swap a fixed amount on a recurring schedule.
+
+```bash
+twak automate add \
+  --type dca \
+  --from-token BNB --to-token USDC \
+  --chain bsc \
+  --amount 0.01 \
+  --interval 24h \
+  --json
+
+twak automate add \
+  --type dca \
+  --from-token ETH --to-token USDC \
+  --chain ethereum \
+  --amount 0.005 \
+  --interval 7d \
+  --json
+```
+
+Intervals: `1h`, `6h`, `12h`, `24h`, `7d`, `30d`.
+
+## Create a Limit Order
+
+One-time swap that executes when price reaches a target.
+
+```bash
+twak automate add \
+  --type limit \
+  --from-token USDC --to-token ETH \
+  --chain ethereum \
+  --amount 100 \
+  --target-price 1800 \
+  --json
+
+twak automate add \
+  --type limit \
+  --from-token USDC --to-token BNB \
+  --chain bsc \
+  --amount 50 \
+  --target-price 400 \
+  --condition below \
+  --json
+```
+
+## List Automations
+
+```bash
+twak automate list --json
+```
+
+## Pause / Resume / Delete
+
+```bash
+twak automate pause <id>
+twak automate resume <id>
+twak automate delete <id>
+```
+
+## Execute Automations
+
+Automations run when `twak watch` is active. The watcher polls prices and executes automations whose conditions are met.
+
+```bash
+twak watch                    # polls every 60s, executes DCA + limit orders
+twak watch --interval 5m     # custom poll interval
+twak watch --dry-run         # check conditions without executing
+twak watch --json            # structured output
+```
+
+## Storage
+
+Automations are stored in `~/.twak/automations.json`. Each entry includes:
+- `id` — unique identifier
+- `type` — `dca` or `limit`
+- `status` — `active`, `paused`, or `completed`
+- `fromToken`, `toToken`, `chain`, `amount`
+- `interval` (DCA) or `targetPrice` + `condition` (limit)
+- `lastExecuted`, `executionCount`


### PR DESCRIPTION
## Summary

- Add `references/automations.md` — DCA (recurring swaps) and limit orders (conditional swaps) documentation
- Update `SKILL.md` routing table with automation entry
- Update `alerts.md` with symbol-based syntax (`--token ETH` instead of `--token c60`) and automation cross-reference

## Changes

- `skills/wallet/SKILL.md` — Add automations row, update description
- `skills/wallet/references/automations.md` — New: DCA add/list/pause/resume/delete, limit orders, `twak watch` execution
- `skills/wallet/references/alerts.md` — Update create examples with symbols, add dry-run, cross-reference automations

🤖 Generated with [Claude Code](https://claude.com/claude-code)