### PR TITLE
chore: Bring command specification up to date

### DIFF
--- a/skills/wallet/references/automations.md
+++ b/skills/wallet/references/automations.md
@@ -3,6 +3,8 @@
 
 Create recurring swaps (DCA) or conditional one-time swaps (limit orders) that execute automatically via `twak watch`.
 
+**Important:** Automations only execute while `twak watch` is running. If the process is stopped, automations are paused until `watch` is started again.
+
 ## Create a DCA Automation
 
 Dollar-cost averaging — swap a fixed amount of the source token (`--from`) on a recurring schedule. `--amount` is always denominated in the source token.
@@ -19,11 +21,12 @@ twak automate add \
   --from ETH --to USDC \
   --chain ethereum \
   --amount 0.005 \
-  --interval 7d \
+  --interval 1h \
+  --max-runs 10 \
   --json
 ```
 
-Intervals: `30s`, `1m`, `5m`, `1h`, `6h`, `12h`, `24h`, `7d`, `30d` (minimum 5s).
+Intervals accept any `<number><s|m|h>` format (e.g. `30s`, `5m`, `1h`, `24h`). Minimum 5s.
 
 ## Create a Limit Order
 
@@ -54,6 +57,15 @@ twak automate add \
   --json
 ```
 
+## Optional Flags
+
+| Flag | Description |
+|------|-------------|
+| `--max-runs <n>` | Stop after N executions. Automation deactivates automatically. |
+| `--expires <date>` | Expiry date in ISO 8601 format (e.g. `2026-04-01`). Automation deactivates after this date. |
+| `--chain <chain>` | Chain key (default: `ethereum`). |
+| `--json` | Structured JSON output. |
+
 ## List Automations
 
 ```bash
@@ -79,12 +91,15 @@ twak watch --dry-run         # check conditions without executing
 twak watch --json            # structured output
 ```
 
+`watch` requires the wallet password to execute swaps. Password is auto-resolved from the OS keychain if configured.
+
 ## Storage
 
 Automations are stored in `~/.twak/automations.json`. Each entry includes:
 - `id` — unique identifier
 - `type` — `dca` or `limit`
-- `status` — `active`, `paused`, or `completed`
+- `active` — whether the automation is currently enabled
 - `fromToken`, `toToken`, `chain`, `amount`
-- `interval` (DCA) or `targetPrice` + `condition` (limit)
-- `lastExecuted`, `executionCount`
+- `intervalMs` (DCA) or `targetPrice` + `condition` (limit)
+- `lastRunAt`, `runCount`
+- `maxRuns`, `expiresAt` (optional)

--- a/skills/wallet/references/balance.md
+++ b/skills/wallet/references/balance.md
@@ -15,7 +15,7 @@ Native token balance on a specific chain (password auto-resolved from OS keychai
 twak wallet balance --chain ethereum --json
 twak wallet balance --chain solana --json
 twak wallet balance --chain bsc --json
-twak wallet balance --all --json                # all chains with funds
+twak wallet balance --all --json
 twak wallet balance --chain ethereum --no-tokens --json  # native only, skip token lookup
 ```
 
@@ -33,7 +33,7 @@ twak wallet portfolio --json
 twak wallet portfolio --chains ethereum,base,bsc,solana --json
 ```
 
-Default chains: all 25 supported chains. Use `--chains` to narrow scope.
+Default chains: ethereum, arbitrum, optimism, polygon, bsc, avalanche, base, fantom, linea, scroll, zksync, blast, sonic, celo, aurora, solana, bitcoin, litecoin, dogecoin, tron, cosmos, near, aptos, ton, sui.
 
 ## Any Address Balance
 

--- a/skills/wallet/references/balance.md
+++ b/skills/wallet/references/balance.md
@@ -15,7 +15,12 @@ Native token balance on a specific chain (password auto-resolved from OS keychai
 twak wallet balance --chain ethereum --json
 twak wallet balance --chain solana --json
 twak wallet balance --chain bsc --json
+twak wallet balance --all --json                # all chains with funds
+twak wallet balance --chain ethereum --no-tokens --json  # native only, skip token lookup
 ```
+
+- `--all` — Show balances across all chains with funds
+- `--no-tokens` — Skip token balance lookup (faster, native balance only)
 
 Output: `{ chain, address, symbol, available, staked, pending, total }`
 
@@ -28,7 +33,7 @@ twak wallet portfolio --json
 twak wallet portfolio --chains ethereum,base,bsc,solana --json
 ```
 
-Default chains: ethereum, base, bsc, polygon, arbitrum, optimism, avalanche, fantom, linea, scroll, zksync, blast, sonic, celo, aurora, solana, tron.
+Default chains: all 25 supported chains. Use `--chains` to narrow scope.
 
 ## Any Address Balance
 

--- a/skills/wallet/references/erc20.md
+++ b/skills/wallet/references/erc20.md
@@ -18,23 +18,36 @@ twak erc20 approve \
   --json
 ```
 
+`--amount` is in the token's smallest unit (e.g. wei for ETH-based tokens), or `unlimited` for max approval.
+
 Examples:
 
 ```bash
-# Approve 100 USDC for Uniswap V3
+# Approve 100000000 units (100 USDC, 6 decimals) for Uniswap V3
 twak erc20 approve \
   --token c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   --spender 0xE592427A0AEce92De3Edee1F18E0157C05861564 \
-  --amount 100 --json
+  --amount 100000000 --json
 
-# Revoke approval (set to 0)
+# Unlimited approval (requires --confirm-unlimited)
 twak erc20 approve \
   --token c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   --spender 0xE592427A0AEce92De3Edee1F18E0157C05861564 \
-  --amount 0 --json
+  --amount unlimited --confirm-unlimited --json
 ```
 
 Output: `{ hash, chain, owner, spender, token, amount, explorer }`
+
+## Revoke Approval
+
+Dedicated command to set allowance to 0:
+
+```bash
+twak erc20 revoke \
+  --token c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
+  --spender 0xE592427A0AEce92De3Edee1F18E0157C05861564 \
+  --json
+```
 
 ## Check Allowance
 
@@ -48,12 +61,28 @@ twak erc20 allowance \
 
 Output: `{ token, owner, spender, allowance }`
 
+## Options
+
+### `erc20 approve`
+- `--token <assetId>` — ERC-20 token asset ID (required)
+- `--spender <address>` — Spender contract address (required)
+- `--amount <n>` — Amount in smallest unit, or `unlimited` (required)
+- `--confirm-unlimited` — Required when using `--amount unlimited` to acknowledge the risk
+- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--json` — Output as JSON
+
+### `erc20 revoke`
+- `--token <assetId>` — ERC-20 token asset ID (required)
+- `--spender <address>` — Spender to revoke (required)
+- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--json` — Output as JSON
+
 ## Safety Notes
 
 - Always verify the spender address is the correct contract
 - Prefer exact amounts over `unlimited` — unlimited approvals are a common attack surface
+- Use `erc20 revoke` to remove approvals you no longer need
 - Check existing allowance before approving to avoid redundant transactions
-- To revoke, approve with `--amount 0`
 
 ## Asset ID Format
 

--- a/skills/wallet/references/history.md
+++ b/skills/wallet/references/history.md
@@ -28,22 +28,22 @@ twak tx <hash> --chain solana --json
 
 ## Own Wallet History
 
-If the user has an agent wallet, get their address first:
+If `--address` is omitted and an agent wallet exists, the address is auto-detected:
 
 ```bash
-twak wallet address --chain ethereum --json
+twak history --chain ethereum --json                    # auto-detects wallet address
+twak history --chain ethereum --json --password <pw>    # explicit password if no keychain
 ```
-
-Then query history with that address.
 
 ## Options
 
 ### `history`
-- `--address <addr>` — Wallet address (required)
-- `--chain <chainKey>` — Chain key (required)
+- `--address <addr>` — Wallet address (auto-detected from agent wallet if omitted)
+- `--chain <chainKey>` — Chain key (omit for bulk history across all chains)
 - `--limit <n>` — Max results (default: 20)
 - `--from <date>` — Start date (YYYY-MM-DD)
 - `--to <date>` — End date (YYYY-MM-DD)
+- `--password <pw>` — Wallet password (for auto-detecting address when `--address` is omitted)
 - `--json` — Output as JSON
 
 ### `tx`

--- a/skills/wallet/references/send.md
+++ b/skills/wallet/references/send.md
@@ -64,6 +64,9 @@ Decimals are resolved automatically via the API.
 - `--to <address>` — Destination address or ENS name (required)
 - `--amount <n>` — Amount in human-readable format (required)
 - `--token <assetId>` — Token asset ID (required)
+- `--confirm-to <address>` — Pin the expected resolved address. Transfer is rejected if ENS resolution returns a different address.
+- `--max-usd <n>` — Maximum allowed transfer value in USD (default: 10000). Transfer is rejected if value exceeds this.
+- `--skip-safety-check` — Bypass the USD value safety check
 - `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
 - `--json` — Output as JSON
 

--- a/skills/wallet/references/swap.md
+++ b/skills/wallet/references/swap.md
@@ -13,15 +13,13 @@ Execute same-chain or cross-chain token swaps via Trust Wallet. Supports all EVM
 Always get a quote before executing to confirm rates and price impact:
 
 ```bash
-twak swap <amount> <fromToken> <toToken> --chain <chainKey> --quote-only --json
-```
-
-Examples:
-
-```bash
+# By amount: twak swap <amount> <from> <to>
 twak swap 1 ETH USDC --chain ethereum --quote-only --json
 twak swap 10 SOL USDC --chain solana --quote-only --json
 twak swap 100 USDC USDC --chain ethereum --to-chain arbitrum --quote-only --json
+
+# By USD value: twak swap <from> <to> --usd <amount>
+twak swap ETH USDC --chain ethereum --usd 100 --quote-only --json
 ```
 
 Only execute after the user confirms the quote.

--- a/skills/wallet/references/swap.md
+++ b/skills/wallet/references/swap.md
@@ -49,6 +49,7 @@ twak swap 0.01 ETH BNB --chain ethereum --to-chain bsc --json
 - `--chain <key>` — Source chain (default: ethereum)
 - `--to-chain <key>` — Destination chain for cross-chain swaps
 - `--slippage <pct>` — Slippage tolerance % (default: 1)
+- `--usd <amount>` — Swap a USD-equivalent amount of the source token (e.g. `twak swap ETH USDC --usd 100`)
 - `--quote-only` — Get quote without executing
 - `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
 - `--json` — Output as JSON

--- a/skills/wallet/references/wallet.md
+++ b/skills/wallet/references/wallet.md
@@ -11,8 +11,11 @@ Non-custodial HD (BIP39) wallet that derives addresses across 25+ chains. Keys r
 
 ```bash
 twak wallet create --password <pw>
-twak wallet create --password <pw> --no-keychain  # skip keychain
+twak wallet create --password <pw> --no-keychain            # skip keychain
+twak wallet create --password <pw> --skip-password-check    # skip strength validation (test only)
 ```
+
+Password must be at least 8 characters with mixed case and a number. Use `--skip-password-check` only for test wallets.
 
 Output includes derived addresses for all major chains.
 
@@ -60,7 +63,11 @@ twak wallet keychain delete
 Connect an external wallet (e.g. Trust Wallet mobile) for interactive transaction approvals:
 
 ```bash
-twak wallet connect
+twak wallet connect --project-id <id>
+twak wallet connect --project-id <id> --chains "eip155:1,eip155:56"
+twak wallet connect --project-id <id> --timeout 120
 ```
 
-Requires `WALLETCONNECT_PROJECT_ID`.
+- `--project-id <id>` — WalletConnect project ID (or set `WALLETCONNECT_PROJECT_ID` env var)
+- `--chains <list>` — Comma-separated CAIP-2 chain IDs (default: major EVM chains)
+- `--timeout <seconds>` — Connection timeout (default: 300)


### PR DESCRIPTION
This pull request updates the wallet CLI documentation to clarify usage, add new options, and improve accuracy and safety notes across automations, balance, ERC-20, transaction history, send, swap, and wallet management commands. The most important changes are grouped below:

**Automations and Scheduling**
- Clarified that automations only run while `twak watch` is active and added a note about password resolution from the OS keychain. [[1]](diffhunk://#diff-4b808b940ad3588bb2483dee6d9a83b5de73b05064766154b69d05559a932c2aR6-R7) [[2]](diffhunk://#diff-4b808b940ad3588bb2483dee6d9a83b5de73b05064766154b69d05559a932c2aR94-R105)
- Expanded interval options to accept flexible time formats (e.g., `1h`, `30s`) and documented new optional flags like `--max-runs` and `--expires`. [[1]](diffhunk://#diff-4b808b940ad3588bb2483dee6d9a83b5de73b05064766154b69d05559a932c2aL22-R29) [[2]](diffhunk://#diff-4b808b940ad3588bb2483dee6d9a83b5de73b05064766154b69d05559a932c2aR60-R68)
- Updated storage format details: renamed fields for clarity (`status` → `active`, `lastExecuted` → `lastRunAt`, etc.) and added new fields (`maxRuns`, `expiresAt`).

**Balance and Portfolio**
- Added `--all` flag to show balances across all chains and `--no-tokens` to skip token lookup for faster native balance checks.
- Clarified that the default portfolio includes all 25 supported chains, not just a subset.

**ERC-20 Approvals and Revocation**
- Clarified that `--amount` is in the token's smallest unit or can be set to `unlimited`, and added a dedicated `erc20 revoke` command for removing approvals.
- Added explicit options tables for `erc20 approve` and `erc20 revoke`, and updated safety notes to recommend using `erc20 revoke` instead of approving zero.

**Transaction History and Address Detection**
- Improved history command UX: if `--address` is omitted, it auto-detects the agent wallet address (with password if needed), and clarified `--chain` is optional for bulk queries.

**Send, Swap, and Wallet Management**
- Added new safety and validation flags for sending (`--confirm-to`, `--max-usd`, `--skip-safety-check`) and for swaps (`--usd` to swap a USD-equivalent amount). [[1]](diffhunk://#diff-25d5823a315e3f6134f2635432215d98c2d06b3cf5191fef43bcd2a2b118282bR67-R69) [[2]](diffhunk://#diff-2d68801b88352b3ab8b748701e82fd182a57c37f4552911c871f11cffa12f06dR52)
- Documented new wallet creation/testing options (`--skip-password-check`) and expanded WalletConnect connection options (`--project-id`, `--chains`, `--timeout`). [[1]](diffhunk://#diff-e5012cbaa3cd0c8821e74c550554943b4585ac1be6f46c5123f2c8a8256bb254R15-R19) [[2]](diffhunk://#diff-e5012cbaa3cd0c8821e74c550554943b4585ac1be6f46c5123f2c8a8256bb254L63-R73)