### PR TITLE
docs(wallet): refresh x402 reference — new quote command + --prefer-* flags + required --max-payment

### DIFF
--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -30,6 +30,6 @@ Read the reference that matches the user's task:
 | DCA & limit orders | `references/automations.md` | "DCA", "dollar cost average", "limit order", "recurring swap", "buy when price" |
 | ERC-20 approve/revoke | `references/erc20.md` | "approve spender", "check allowance", "revoke" |
 | Token risk checks | `references/token-risk.md` | "is this token safe", "honeypot check", "audit status" |
-| x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API" |
+| x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API", "preview payment", "quote endpoint cost", "how much does this API charge" |
 
 Read `references/setup.md` alongside any other reference if the CLI isn't installed yet.

--- a/skills/wallet/references/x402.md
+++ b/skills/wallet/references/x402.md
@@ -193,18 +193,7 @@ If filtering plus the signable check eliminate every entry, the picker returns `
 
 EIP-3009 is always cheaper for the buyer (no approval, no gas) so it wins by default whenever offered with valid metadata.
 
-## Server — Run a Payment-Gated API
-
-```bash
-twak serve --rest \
-  --x402 \
-  --payment-amount 0.01 \
-  --payment-asset usdc \
-  --payment-chain eip155:8453 \
-  --payment-recipient 0xYourAddress
-```
-
-## Inline Help
+## Payment Info
 
 ```bash
 twak x402 info

--- a/skills/wallet/references/x402.md
+++ b/skills/wallet/references/x402.md
@@ -1,52 +1,100 @@
 
 # x402 Micropayments
 
-x402 is an HTTP payment protocol built on the 402 Payment Required status code. When a server requires payment, the client automatically pays and retries.
+x402 is an HTTP payment protocol built on the 402 Payment Required status code. When a server requires payment, the client signs a payment authorization on-chain and retries with the proof.
 
 ## Client — Access a Paid Endpoint
 
 ```bash
-twak x402 request <url>
+twak x402 request <url> --max-payment <atomic>
 ```
 
 ### Flow
 
-1. Client sends HTTP request without payment
-2. Server returns `402 Payment Required` with payment details
-3. Client pays on-chain and retries with payment proof
-4. Server verifies and returns the response
+1. Client sends HTTP request without payment.
+2. Server returns `402 Payment Required` with a challenge listing one or more `accepts` entries (chain + asset + amount + transfer method).
+3. Client picker selects the best entry (EIP-3009 gasless preferred over Permit2). User confirms unless `--yes`.
+4. Client signs a payment authorization (EIP-3009 transferWithAuthorization) or Permit2 witness, attaches it to the `PAYMENT-SIGNATURE` header, and retries.
+5. Server verifies on-chain settlement and returns the resource.
 
 ### Examples
 
 ```bash
-# GET request (prompts for confirmation before paying)
-twak x402 request https://api.example.com/data --json
+# Minimum: pay up to 0.01 USDC (10000 atomic at 6dp). Prompts for confirmation.
+twak x402 request https://api.example.com/data --max-payment 10000 --json
 
-# Skip confirmation for trusted endpoints
-twak x402 request https://api.example.com/data --yes --json
+# Skip prompts (auto-confirm payments up to --max-payment)
+twak x402 request https://api.example.com/data --max-payment 10000 --yes --json
 
-# Raise payment cap
-twak x402 request https://api.example.com/premium --max-payment 0.5 --yes --json
+# Force a specific chain (e.g. settle on BSC instead of Base)
+twak x402 request https://api.example.com/data \
+  --max-payment 10000 --prefer-network bsc --yes --json
+
+# Force a specific transfer method
+twak x402 request https://api.example.com/data \
+  --max-payment 10000 --prefer-method eip3009 --yes --json
+
+# Pick a specific token by name substring (case-insensitive) or contract address
+twak x402 request https://api.example.com/data \
+  --max-payment 10000000000000000 --prefer-asset "Tether" --yes --json
+
+twak x402 request https://api.example.com/data \
+  --max-payment 10000 --prefer-asset 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --yes --json
 
 # POST with JSON body
 twak x402 request https://api.example.com/analyze \
-  --method POST --body '{"query":"price of ETH"}' --yes --json
+  --method POST --body '{"query":"price of ETH"}' \
+  --max-payment 10000 --yes --json
+
+# First-time Permit2: also skip the one-time approval prompt (you pay gas for this tx)
+twak x402 request https://api.example.com/data \
+  --max-payment 10000 --yes --auto-approve --json
 ```
 
 ### Safety
 
-- Only `https://` URLs accepted
-- Payment capped by `--max-payment` (default: 0.01)
-- Interactive confirmation before payment unless `--yes` is passed
+- Only `https://` URLs accepted; private/loopback IPs (including IPv4-mapped IPv6 like `::ffff:127.0.0.1`) rejected before any network call.
+- `--max-payment` is required and capped against the server's requested amount; negative server amounts are rejected.
+- Interactive confirmation before signing unless `--yes` is passed. Confirm prompt surfaces the asset contract address so a malicious `extra.name` cannot masquerade as the wrong token.
+- Permit2 first-time approval requires a separate confirmation unless `--auto-approve` is passed (or `--yes` is on, which auto-approves the payment but **not** the Permit2 allowance — keep these independent).
 
 ### Client Options
 
-- `--method <method>` — HTTP method: GET, POST, PUT, DELETE (default: GET)
-- `--body <json>` — JSON request body
-- `--max-payment <amount>` — Max auto-approved payment (default: 0.01)
-- `--yes` — Skip confirmation prompt
-- `--password <pw>` — Wallet password (resolved from keychain if omitted)
-- `--json` — Output as JSON
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--max-payment <atomic>` | string (integer atomic units) | yes | Max payment to auto-approve, in atomic units of the chosen asset (e.g. `"10000"` = 0.01 USDC at 6dp; `"10000000000000000"` = 0.01 of an 18-dp token). |
+| `--method <method>` | `GET` \| `POST` \| `PUT` \| `DELETE` \| `HEAD` | no | HTTP method (default: `GET`). Body is stripped on `GET` and `HEAD`. |
+| `--body <json>` | string | no | Raw request body. Sent verbatim with `Content-Type: application/json`. |
+| `--prefer-network <network>` | string | no | Restrict route to this chain. Accepts a TWAK chain key (`"base"`, `"bsc"`, `"ethereum"`, `"polygon"`, …) or a CAIP-2 string (`"eip155:8453"`). AND-combined with `--prefer-method`/`--prefer-asset`. |
+| `--prefer-method <method>` | `eip3009` \| `permit2-exact` | no | Restrict route to this transfer method. Default picker prefers `eip3009` (gasless) when offered. |
+| `--prefer-asset <addr-or-name>` | string | no | Restrict route to this asset. Accepts a contract address (exact, case-insensitive) **or** a token-name substring matched against `extra.name` (`"Tether"`, `"USDC"`, `"United Stables"`). |
+| `--yes` | boolean | no | Skip the per-payment confirmation prompt. Still respects `--max-payment`. |
+| `--auto-approve` | boolean | no | Skip the Permit2 first-time approval prompt and broadcast `approve(Permit2, MAX)` (you pay gas; runs once per token+chain). Independent from `--yes`. |
+| `--password <pw>` | string | no | Wallet password. Resolves from keychain or `TWAK_WALLET_PASSWORD` if omitted. |
+| `--json` | boolean | no | Emit JSON output. Error envelope: `{ "error": <message>, "errorCode": <code> }`. |
+
+### Error Codes (JSON output)
+
+| `errorCode` | When |
+|-------------|------|
+| `VALIDATION_ERROR` | `http://` URL, private/loopback IP, DNS rebind to a private IP, or invalid `--max-payment`. |
+| `CHAIN_UNSUPPORTED` | The 402 challenge offers a chain TWAK does not support. |
+| `NO_MATCHING_ROUTE` | One of `--prefer-network`/`--prefer-method`/`--prefer-asset` filtered out every offered entry. Message includes the active filters and the full offered list. |
+| `PAYMENT_AMOUNT_EXCEEDED` | Server's requested amount exceeds `--max-payment`. |
+| `PAYMENT_INVALID_CHALLENGE` | The 402 body/header is missing required fields or fails schema validation. |
+| `PAYMENT_CANCELLED` | User answered `n` at the confirmation prompt. |
+| `PERMIT2_APPROVAL_REQUIRED` | Permit2 route chosen, allowance is zero, user declined the approval prompt. |
+| `NETWORK_ERROR` | The server returned a non-2xx, non-402 status. |
+
+## Picker Behaviour
+
+When the server offers multiple `accepts` entries:
+
+1. **Filter** by `--prefer-network` / `--prefer-method` / `--prefer-asset` (AND-combined). Empty result → `NO_MATCHING_ROUTE`.
+2. **Prefer EIP-3009** entries with both `extra.name` and `extra.version` set (signable, gasless, no approval).
+3. **Fall back** to Permit2 (`permit2-exact`) on the first surviving entry. Requires a one-time `approve(Permit2, MAX)` if the wallet has not approved the token before.
+
+EIP-3009 is always cheaper for the buyer (no approval, no gas) so it wins by default whenever offered with valid metadata.
 
 ## Server — Run a Payment-Gated API
 
@@ -59,18 +107,20 @@ twak serve --rest \
   --payment-recipient 0xYourAddress
 ```
 
-## Payment Info
+## Inline Help
 
 ```bash
 twak x402 info
 ```
 
-## Supported Payment Assets
+## Supported Settlement Routes
 
-| Asset | Chain ID | Chain |
-|-------|----------|-------|
-| USDC | eip155:8453 | Base |
-| USDC | eip155:1 | Ethereum |
-| USDC | eip155:137 | Polygon |
+EIP-3009 settlement is supported on any EVM chain TWAK knows about where the token contract implements `transferWithAuthorization`. Permit2-exact is supported on any EVM chain Uniswap's Permit2 contract is deployed to. The picker delegates chain support to the TWAK chain map; offering an unsupported chain returns `CHAIN_UNSUPPORTED`.
 
-Base is recommended — low fees and fast finality.
+Common live routes (subject to merchant configuration):
+
+| Asset | Chain | Method | Notes |
+|-------|-------|--------|-------|
+| USDC | `base` (`eip155:8453`) | EIP-3009 | Recommended — low fees, gasless, fast finality. |
+| USDC | `bsc` (`eip155:56`) | EIP-3009 / Permit2-exact | Available on most merchants. |
+| USDT | `bsc` (`eip155:56`) | EIP-3009 / Permit2-exact | Atomic units at 18dp on BSC. |

--- a/skills/wallet/references/x402.md
+++ b/skills/wallet/references/x402.md
@@ -135,7 +135,7 @@ JSON mode emits the full `QuoteX402Result`:
       "tokenName": "USD Coin",          // Seller-controlled (`extra.name`); raw — sanitize before rendering to a terminal.
       "amount": "10000",                // Atomic units (string, decimals-of-asset).
       "payTo": "0x271189c860DB25bC43173B0335784aD68a680908",
-      "transferMethod": "eip3009",      // or "permit2-exact" / "permit2-upto".
+      "transferMethod": "eip3009",      // or "permit2-exact".
       "maxTimeoutSeconds": 30,
       "preferred": true,                // True for the route the client would pick if you called `twak x402 request` with no filters.
       "requiresApproval": false,        // True for Permit2 routes (one-time `approve(Permit2, MAX)` needed before first payment).
@@ -183,8 +183,13 @@ Sorted preferred-first in both modes. If the preferred kind happens to be on a c
 When the server offers multiple `accepts` entries:
 
 1. **Filter** by `--prefer-network` / `--prefer-method` / `--prefer-asset` (AND-combined). Empty result → `NO_MATCHING_ROUTE`.
-2. **Prefer EIP-3009** entries with both `extra.name` and `extra.version` set (signable, gasless, no approval).
-3. **Fall back** to Permit2 (`permit2-exact`) on the first surviving entry. Requires a one-time `approve(Permit2, MAX)` if the wallet has not approved the token before.
+2. **Skip unsignable entries.** Each kept entry must be a method the client can sign:
+   - EIP-3009 entries **require** `extra.name` and `extra.version` (used to build the EIP-712 domain separator). Entries missing either field are skipped entirely — not signable, even if they're the only EIP-3009 option offered.
+   - `permit2-exact` is signable as long as the chain is supported.
+3. **Prefer EIP-3009** over Permit2 among the surviving entries (no approval, no gas).
+4. **Fall back** to Permit2 (`permit2-exact`) on the first surviving entry. Requires a one-time `approve(Permit2, MAX)` if the wallet has not approved the token before.
+
+If filtering plus the signable check eliminate every entry, the picker returns `NO_MATCHING_ROUTE` (when an explicit `--prefer-*` flag is in play) or a generic "no supported route" error (when nothing the endpoint offered is signable).
 
 EIP-3009 is always cheaper for the buyer (no approval, no gas) so it wins by default whenever offered with valid metadata.
 

--- a/skills/wallet/references/x402.md
+++ b/skills/wallet/references/x402.md
@@ -86,6 +86,98 @@ twak x402 request https://api.example.com/data \
 | `PERMIT2_APPROVAL_REQUIRED` | Permit2 route chosen, allowance is zero, user declined the approval prompt. |
 | `NETWORK_ERROR` | The server returned a non-2xx, non-402 status. |
 
+## Quote — Preview Payment Options Without Signing
+
+```bash
+twak x402 quote <url>
+```
+
+Read-only. Fetches the 402 challenge, parses it, and renders the available payment routes. No wallet password required — no on-chain action is taken.
+
+Use this when:
+- The user wants to see what an endpoint charges before committing to pay.
+- An agent needs to surface a route menu to the user so they can pick which asset/chain to settle on.
+- You're debugging a `NO_MATCHING_ROUTE` from `twak x402 request` and want to see what the server actually offered.
+
+### Examples
+
+```bash
+# Preview a GET endpoint
+twak x402 quote https://api.example.com/data
+
+# Preview with the same method + body shape you plan to pay with
+twak x402 quote https://api.example.com/analyze \
+  --method POST --body '{"query":"price of ETH"}'
+
+# Emit the full JSON shape for scripting / agent consumption
+twak x402 quote https://api.example.com/data --json
+```
+
+### Output Shape
+
+Text mode renders a table sorted preferred-first (chains TWAK does not support are filtered out, with a `Filtered N route(s)` warning) plus a `Next:` line containing the literal `twak x402 request …` command you should run to pay. URL, `--method`, and `--body` are shell-quoted in the `Next:` line for safe copy-paste.
+
+JSON mode emits the full `QuoteX402Result`:
+
+```jsonc
+{
+  "success": true,
+  "resource": {                         // Only present on x402 v2 challenges.
+    "url": "https://api.example.com/data",
+    "description": "…",
+    "mimeType": "application/json"
+  },
+  "accepts": [                          // Full unfiltered list — exactly what the endpoint offered.
+    {
+      "network": "eip155:8453",         // CAIP-2 chain ID.
+      "scheme": "exact",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "tokenName": "USD Coin",          // Seller-controlled (`extra.name`); raw — sanitize before rendering to a terminal.
+      "amount": "10000",                // Atomic units (string, decimals-of-asset).
+      "payTo": "0x271189c860DB25bC43173B0335784aD68a680908",
+      "transferMethod": "eip3009",      // or "permit2-exact" / "permit2-upto".
+      "maxTimeoutSeconds": 30,
+      "preferred": true,                // True for the route the client would pick if you called `twak x402 request` with no filters.
+      "requiresApproval": false,        // True for Permit2 routes (one-time `approve(Permit2, MAX)` needed before first payment).
+      "description": "10000 of USD Coin on eip155:8453 via eip3009 (gasless)"  // Sanitized: control chars stripped.
+    }
+  ],
+  "summary": "Endpoint offers 3 payment option(s). Default route: 10000 of USD Coin on eip155:8453 via eip3009 (gasless).",
+  "nextAction": "Show these payment options to the user. Default route is 10000 USD Coin on Base. Pick one and run: twak x402 request 'https://api.example.com/data' --max-payment 10000 --prefer-asset <picked asset>. Omit --prefer-asset to use the default."
+}
+```
+
+Failure envelope (HTTPS validation failure, endpoint not a 402, malformed challenge, etc.):
+
+```jsonc
+{
+  "success": false,
+  "code": "NETWORK_ERROR",              // VALIDATION_ERROR / NO_PAYMENT_REQUIRED / PAYMENT_INVALID_CHALLENGE / CHAIN_UNSUPPORTED / NETWORK_ERROR
+  "message": "Endpoint returned 500 Internal Server Error; expected 402 challenge.",
+  "status": 500,                        // HTTP status (when applicable)
+  "error": "Endpoint returned 500 …",   // Same as `message`; legacy envelope key.
+  "errorCode": "NETWORK_ERROR"          // Same as `code`; legacy envelope key.
+}
+```
+
+### Filtering Semantics
+
+The CLI text mode filters out routes on chains TWAK doesn't sign for (e.g. `eip155:196` X-Layer); the JSON output keeps the full unfiltered list under `accepts` so scripts can see exactly what the endpoint offered. Process exit code is `1` when filtering drops every route (i.e. the endpoint offered nothing this client can pay).
+
+### Sort Order
+
+Sorted preferred-first in both modes. If the preferred kind happens to be on a chain TWAK can't sign on, `preferred` is `false` for every entry and `nextAction` falls back to a "no supported route" message.
+
+### Quote Options
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--method <method>` | `GET` \| `POST` \| `PUT` \| `DELETE` \| `HEAD` | no | HTTP method (default: `GET`). Body is stripped on `GET` and `HEAD`. Must match the method you plan to use on `twak x402 request` — the server may emit a different 402 for a different verb. |
+| `--body <json>` | string | no | Raw request body. Must match the body you plan to use on `twak x402 request`. |
+| `--json` | boolean | no | Emit the JSON shape above. Without `--json`, renders the human-readable table. |
+
+`twak x402 quote` does NOT take `--max-payment`, `--password`, `--prefer-*`, `--yes`, or `--auto-approve` — it's read-only.
+
 ## Picker Behaviour
 
 When the server offers multiple `accepts` entries:


### PR DESCRIPTION
## Summary

- Document `twak x402 quote <url>` — a new read-only command for previewing payment options without signing. Includes the full `QuoteX402Result` JSON shape (sorted preferred-first, unfiltered `accepts` for scripts) so agents can build menus before calling `twak x402 request`.
- Document the three picker overrides on `twak x402 request`: `--prefer-network`, `--prefer-method`, `--prefer-asset`.
- Correct `--max-payment` — it is **required** and takes **atomic units** (integer string), not optional with a `0.01` default in dollars.
- Add `--auto-approve` (Permit2 first-time approval).
- Add an error-code table mapping `--json` envelope codes (`VALIDATION_ERROR`, `CHAIN_UNSUPPORTED`, `NO_MATCHING_ROUTE`, `PAYMENT_AMOUNT_EXCEEDED`, `PAYMENT_INVALID_CHALLENGE`, `PAYMENT_CANCELLED`, `PERMIT2_APPROVAL_REQUIRED`, `NETWORK_ERROR`).
- Document picker behaviour (EIP-3009 preferred over Permit2; entries missing `extra.name`/`version` are skipped).
- Refresh the supported-routes table.
- Expand SKILL.md routing keywords with quote-shaped triggers ("preview payment", "quote endpoint cost", "how much does this API charge").

Companion to trustwallet/twak#90 (initial --prefer-* + required --max-payment) and trustwallet/twak#105 (which merges in the new `quote` subcommand from #106).

## Test plan

- [x] An agent following this reference can construct a valid `twak x402 request` invocation against a multi-route endpoint (e.g. an x402-gated DEX search with both Base USDC and BSC USDT) and narrow to a specific route via `--prefer-*`.
- [x] An agent can call `twak x402 quote --json`, surface the menu to the user, and translate the user's pick into the right `--prefer-asset` flag on the follow-up `twak x402 request`.
- [x] `--json` error envelopes documented match what the CLI emits for each error path.