### PR TITLE
docs(wallet): remove x402 server-side block

### DIFF
--- a/skills/wallet/references/x402.md
+++ b/skills/wallet/references/x402.md
@@ -48,17 +48,6 @@ twak x402 request https://api.example.com/analyze \
 - `--password <pw>` — Wallet password (resolved from keychain if omitted)
 - `--json` — Output as JSON
 
-## Server — Run a Payment-Gated API
-
-```bash
-twak serve --rest \
-  --x402 \
-  --payment-amount 0.01 \
-  --payment-asset usdc \
-  --payment-chain eip155:8453 \
-  --payment-recipient 0xYourAddress
-```
-
 ## Payment Info
 
 ```bash


### PR DESCRIPTION
The `twak serve --x402 / --payment-*` server-side capability was removed in `trustwallet/twak` PR #117 and ships in twak v0.15.0. The client-side x402 surface (`twak x402 quote/request/info`, `x402_request` MCP action) is unchanged.