### PR TITLE
docs(wallet): document twak compete command

### DIFF
--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -31,5 +31,6 @@ Read the reference that matches the user's task:
 | ERC-20 approve/revoke | `references/erc20.md` | "approve spender", "check allowance", "revoke" |
 | Token risk checks | `references/token-risk.md` | "is this token safe", "honeypot check", "audit status" |
 | x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API", "preview payment", "quote endpoint cost", "how much does this API charge" |
+| BNB Hack competition register/status | `references/compete.md` | "register for the competition", "BNB hack", "AI trading agent edition", "compete", "registration status" |
 
 Read `references/setup.md` alongside any other reference if the CLI isn't installed yet.

--- a/skills/wallet/references/automations.md
+++ b/skills/wallet/references/automations.md
@@ -3,7 +3,7 @@
 
 Create recurring swaps (DCA) or conditional one-time swaps (limit orders) that execute automatically via `twak watch`.
 
-**Important:** Automations only execute while `twak watch` is running. If the process is stopped, automations are paused until `watch` is started again.
+**Important:** Automations only execute while a watcher is polling — either a standalone `twak watch` process, or an MCP server started with `twak serve --watch`. Without one, rules are saved but never fire. If the watcher is stopped, automations are paused until it is started again.
 
 ## Create a DCA Automation
 
@@ -92,6 +92,21 @@ twak watch --json            # structured output
 ```
 
 `watch` requires the wallet password to execute swaps. Password is auto-resolved from the OS keychain if configured.
+
+## Running under the MCP server
+
+When driving twak over MCP (`twak serve`), automations created with the `create_automation` action only execute if the server was launched with `--watch`.
+
+```bash
+twak serve --watch                      # polls every 60s by default
+twak serve --watch --watch-interval 5m  # custom poll interval
+```
+
+Without `--watch` (or a separate `twak watch` process), automations are saved but never fire.
+
+- Automations execute using the local agent wallet; the watcher stays idle in WalletConnect mode, where each swap needs interactive approval.
+- To execute a saved automation once immediately, use the `run_automation_now` action.
+- Don't run both `twak serve --watch` and `twak watch` against the same wallet / `~/.twak/automations.json` — both loops would fire the same automation.
 
 ## Storage
 

--- a/skills/wallet/references/compete.md
+++ b/skills/wallet/references/compete.md
@@ -1,0 +1,55 @@
+
+# BNB HACK: AI TRADING AGENT EDITION
+
+Register your agent wallet for the **BNB HACK: AI TRADING AGENT EDITION** competition and check its registration status. Registration is a one-time on-chain transaction to a registry contract on BNB Smart Chain (BSC). Both subcommands operate only on BSC — there is no `--chain` flag.
+
+## Prerequisites
+
+- Authenticated (`twak auth status`)
+- Agent wallet created (`twak wallet create --password <pw>`) — the registered address is derived from your stored wallet on BSC
+- A small amount of BNB on BSC to cover gas for `register` (a real on-chain transaction)
+
+## Check Status
+
+```bash
+twak compete status --json
+```
+
+Output: `{ registered, participant, opensAt, deadline, open, secondsRemaining, chain }`
+
+- `registered` (boolean) — whether `participant` is already registered
+- `participant` — your agent wallet address on BSC
+- `opensAt` — ISO timestamp when the registration window opens
+- `deadline` — ISO timestamp when the registration window closes
+- `open` (boolean) — `true` when the current time is within `[opensAt, deadline)`
+- `secondsRemaining` — seconds left until `deadline` while `open`, otherwise `0`
+- `chain` — always `bsc`
+
+## Register
+
+```bash
+twak compete register --json
+```
+
+Registers `participant` on-chain. The command is idempotent and validates the window client-side before spending gas:
+
+- **Already registered** → returns `{ registered: true, alreadyRegistered: true, participant, deadline, chain }` without sending a transaction.
+- **Before `opensAt`** → fails with `VALIDATION_ERROR` ("registration not open yet").
+- **After `deadline`** → fails with `VALIDATION_ERROR` ("registration closed").
+- **Within the window** → submits the transaction, waits for confirmation, and verifies the on-chain `Registered` event (missing event → `TX_FAILED`).
+
+Success output: `{ registered: true, participant, deadline, hash, chain, explorer }`
+
+- `hash` — registration transaction hash
+- `explorer` — BscScan URL for the transaction
+
+## Options
+
+Both `compete status` and `compete register` accept:
+
+- `--password <pw>` — Wallet password (resolved from the OS keychain or `TWAK_WALLET_PASSWORD` if omitted)
+- `--json` — Output as JSON
+
+## Registry Contract
+
+Registration targets the competition registry deployed on BSC at `0x212c61B9B72C95d95BF29CF032F5E5635629Aed5`. Override the target with the `COMPETITION_REGISTRY_ADDRESS` environment variable (defaults to the built-in deployment).

--- a/skills/wallet/references/compete.md
+++ b/skills/wallet/references/compete.md
@@ -7,7 +7,6 @@ Register your agent wallet for the **BNB HACK: AI TRADING AGENT EDITION** compet
 
 - Authenticated (`twak auth status`)
 - Agent wallet created (`twak wallet create --password <pw>`) — the registered address is derived from your stored wallet on BSC
-- A small amount of BNB on BSC to cover gas for `register` (a real on-chain transaction)
 
 ## Check Status
 
@@ -31,7 +30,7 @@ Output: `{ registered, participant, opensAt, deadline, open, secondsRemaining, c
 twak compete register --json
 ```
 
-Registers `participant` on-chain. The command is idempotent and validates the window client-side before spending gas:
+Registers `participant` on-chain. The command is idempotent and validates the window client-side before submitting a transaction:
 
 - **Already registered** → returns `{ registered: true, alreadyRegistered: true, participant, deadline, chain }` without sending a transaction.
 - **Before `opensAt`** → fails with `VALIDATION_ERROR` ("registration not open yet").
@@ -52,4 +51,4 @@ Both `compete status` and `compete register` accept:
 
 ## Registry Contract
 
-Registration targets the competition registry deployed on BSC at `0x212c61B9B72C95d95BF29CF032F5E5635629Aed5`. Override the target with the `COMPETITION_REGISTRY_ADDRESS` environment variable (defaults to the built-in deployment).
+Registration targets the competition registry deployed on BSC at `0x212c61B9B72C95d95BF29CF032F5E5635629Aed5`.


### PR DESCRIPTION
Documents the new `twak compete` command for the BNB HACK: AI TRADING AGENT EDITION competition.

- Adds `skills/wallet/references/compete.md` covering `compete status` and `compete register` — BSC-only on-chain registration, JSON output fields, registration-window validation, and options.
- Adds a routing row to `skills/wallet/SKILL.md`.

Mirrors the existing reference format (onramp / erc20).