### PR TITLE
docs(wallet): --chain/bsctestnet support + erc8004/erc8183 command references

### DIFF
--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -33,5 +33,6 @@ Read the reference that matches the user's task:
 | x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API", "preview payment", "quote endpoint cost", "how much does this API charge" |
 | BNB Hack competition register/status | `references/compete.md` | "register for the competition", "BNB hack", "AI trading agent edition", "compete", "registration status" |
 | Register/manage ERC-8004 agent identities | `references/erc8004.md` | "register agent identity", "erc8004", "agent NFT", "agentURI", "agent metadata", "identity registry", "mint agent" |
+| Agent job escrows (ERC-8183 Agentic Commerce) | `references/erc8183.md` | "erc8183", "agentic commerce", "job escrow", "create job", "fund job", "submit deliverable", "settle job", "agent payment escrow", "evaluator router" |
 
 Read `references/setup.md` alongside any other reference if the CLI isn't installed yet.

--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -32,5 +32,6 @@ Read the reference that matches the user's task:
 | Token risk checks | `references/token-risk.md` | "is this token safe", "honeypot check", "audit status" |
 | x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API", "preview payment", "quote endpoint cost", "how much does this API charge" |
 | BNB Hack competition register/status | `references/compete.md` | "register for the competition", "BNB hack", "AI trading agent edition", "compete", "registration status" |
+| Register/manage ERC-8004 agent identities | `references/erc8004.md` | "register agent identity", "erc8004", "agent NFT", "agentURI", "agent metadata", "identity registry", "mint agent" |
 
 Read `references/setup.md` alongside any other reference if the CLI isn't installed yet.

--- a/skills/wallet/references/erc20.md
+++ b/skills/wallet/references/erc20.md
@@ -3,6 +3,15 @@
 
 Grant or inspect spending permissions for ERC-20 tokens on EVM chains. Required when a DeFi protocol needs permission to move tokens on your behalf.
 
+## Specifying the token
+
+Every `erc20` subcommand takes the token in one of two ways:
+
+- **By asset ID** (default) — `--token c{coinId}_t{contractAddress}`, no `--chain`. The chain is derived from the coin ID.
+- **By chain key** — `--chain <key> --token <contractAddress>`, where `--token` is a bare contract address (`0x…`).
+
+Do not combine an asset ID with `--chain` — that is rejected. Native coins have no allowance, so an asset ID without a `_t<address>` part is also rejected.
+
 ## Prerequisites
 
 - Authenticated (`twak auth status`)
@@ -64,17 +73,26 @@ Output: `{ token, owner, spender, allowance }`
 ## Options
 
 ### `erc20 approve`
-- `--token <assetId>` — ERC-20 token asset ID (required)
+- `--token <assetIdOrAddress>` — Without `--chain`: ERC-20 asset ID. With `--chain`: the token contract address (required)
 - `--spender <address>` — Spender contract address (required)
 - `--amount <n>` — Amount in smallest unit, or `unlimited` (required)
+- `--chain <key>` — Chain key (e.g. `base`, `bsctestnet`). When set, `--token` is the token contract address.
 - `--confirm-unlimited` — Required when using `--amount unlimited` to acknowledge the risk
 - `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
 - `--json` — Output as JSON
 
 ### `erc20 revoke`
-- `--token <assetId>` — ERC-20 token asset ID (required)
+- `--token <assetIdOrAddress>` — Without `--chain`: ERC-20 asset ID. With `--chain`: the token contract address (required)
 - `--spender <address>` — Spender to revoke (required)
+- `--chain <key>` — Chain key (e.g. `base`, `bsctestnet`). When set, `--token` is the token contract address.
 - `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--json` — Output as JSON
+
+### `erc20 allowance`
+- `--token <assetIdOrAddress>` — Without `--chain`: ERC-20 asset ID. With `--chain`: the token contract address (required)
+- `--owner <address>` — Owner address (required)
+- `--spender <address>` — Spender address (required)
+- `--chain <key>` — Chain key (e.g. `base`, `bsctestnet`). When set, `--token` is the token contract address.
 - `--json` — Output as JSON
 
 ## Safety Notes
@@ -89,3 +107,11 @@ Output: `{ token, owner, spender, allowance }`
 - ERC-20 tokens: `c{coinId}_t{contractAddress}`
   - `c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` — USDC on Ethereum
   - `c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7` — USDT on Ethereum
+
+## BSC Testnet
+
+Pass `--chain bsctestnet` to approve/revoke/check allowances on BSC testnet (chain ID 97). The testnet key is not listed by `twak chains` and `--token` must be a contract address:
+
+```bash
+twak erc20 approve --chain bsctestnet --token 0x… --spender 0x… --amount unlimited --confirm-unlimited --json
+```

--- a/skills/wallet/references/erc8004.md
+++ b/skills/wallet/references/erc8004.md
@@ -1,0 +1,136 @@
+
+# ERC-8004 Identity Registry
+
+On-chain registry of AI-agent identities on EVM chains. Registering mints an NFT whose token ID is the `agentId`; the caller becomes the owner. Each identity carries an `agentURI` (points to the agent's registration JSON) plus optional free-form on-chain `metadata` key/value entries.
+
+## Known deployments
+
+`erc8004` commands default to `--chain bsc`. Known registry deployments:
+
+- `bsc` — `0x8004a169fb4a3325136eb29fa0ceb6d2e539a432`
+- `bsctestnet` — `0x8004a818bfb912233c491871b3d84c89a494bd9e` (chain ID 97; not listed by `twak chains`)
+
+For any other EVM chain, set `ERC8004_REGISTRY_ADDRESS=0x…` to target a custom deployment. ERC-8004 is EVM-only: a non-EVM chain, or an EVM chain with no known deployment and no env override, fails with `CHAIN_UNSUPPORTED`.
+
+## Metadata value encoding
+
+Every metadata **value** (`register --metadata`, `set-metadata --value`) is encoded by the same rule:
+
+- a `0x`-prefixed hex string is sent as raw bytes — `0x01` → byte `0x01`
+- any other string is UTF-8 encoded — `twak` → `0x7477616b`
+
+Reads (`get-metadata`) return the raw on-chain bytes as a `0x`-hex string; an unset key returns `0x`.
+
+## Prerequisites
+
+- Authenticated (`twak auth status`)
+- Agent wallet created (`twak wallet create --password <pw>`) — the owner is your stored wallet address on the target chain
+
+Writes (`register`, `set-uri`, `set-metadata`) need the wallet; reads (`get-metadata`, `show`) do not.
+
+## Register an Identity
+
+```bash
+twak erc8004 register --uri <agentURI> --json
+```
+
+Mints a new identity; you become the owner. `--uri` is stored on-chain as the token URI and should point to the agent registration JSON. It accepts:
+
+- `https://…` or `ipfs://…` — a hosted URI
+- `data:application/json;base64,…` — the agent card inlined directly on-chain (no external hosting)
+
+### Atomic register + metadata
+
+Pass `--metadata key=value` (repeatable) to write metadata entries in the **same transaction** as the mint:
+
+```bash
+twak erc8004 register \
+  --uri data:application/json;base64,eyJuYW1lIjoibXktYWdlbnQiLCJkZXNjcmlwdGlvbiI6Im15IEFJIGFnZW50IiwidmVyc2lvbiI6IjEifQ== \
+  --metadata client=twak \
+  --metadata version=0x01 \
+  --json
+```
+
+Success output: `{ agentId, owner, agentURI, metadata?, hash, chain, explorer }`
+
+- `agentId` — the minted NFT token ID (decimal string)
+- `owner` — your wallet address
+- `agentURI` — the stored token URI (echoes `--uri`)
+- `metadata` — present only when `--metadata` was passed; an object `{ key: "0x<hexValue>" }` per entry (e.g. `{ "client": "0x7477616b", "version": "0x01" }`)
+- `hash` — mint transaction hash
+- `explorer` — block-explorer URL
+
+## Update the agentURI
+
+```bash
+twak erc8004 set-uri <agentId> --uri <newURI> --json
+```
+
+Replaces the stored token URI (caller must own the NFT). `--uri` accepts the same `https://` / `ipfs://` / `data:` forms as `register`.
+
+Output: `{ agentId, agentURI, hash, chain, explorer }`
+
+## Set a Metadata Entry
+
+```bash
+twak erc8004 set-metadata <agentId> --key <key> --value <hex|string> --json
+```
+
+Sets one metadata entry. `--value` follows the encoding rule above. Pass `--value 0x` to clear an entry.
+
+Output: `{ agentId, key, value, hash, chain, explorer }` — `value` is the `0x`-hex bytes actually written.
+
+## Read a Metadata Entry
+
+```bash
+twak erc8004 get-metadata <agentId> --key <key> --json
+```
+
+Output: `{ agentId, key, value, chain }` — `value` is the raw on-chain bytes as a `0x`-hex string; an unset key returns `0x`.
+
+## Show an Identity
+
+```bash
+twak erc8004 show <agentId> --json
+```
+
+Output: `{ agentId, owner, agentWallet, agentURI, chain }` — `agentWallet` is `null` when unset (zero address).
+
+## Options
+
+### `erc8004 register`
+- `--uri <url>` — Agent registration URI: `https://`, `ipfs://`, or `data:` inline (required)
+- `--metadata <key=value>` — Metadata entry to set atomically with the mint; repeatable. Value is `0x`-hex bytes or a UTF-8 string
+- `--chain <key>` — EVM chain key (default `bsc`; `bsctestnet` supported; other EVM chains need `ERC8004_REGISTRY_ADDRESS`)
+- `--password <pw>` — Wallet password (resolved from OS keychain / `TWAK_WALLET_PASSWORD` if omitted)
+- `--json` — Output as JSON
+
+### `erc8004 set-uri <agentId>`
+- `--uri <url>` — New agent URI: `https://`, `ipfs://`, or `data:` inline (required)
+- `--chain <key>` — EVM chain key (default `bsc`)
+- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--json` — Output as JSON
+
+### `erc8004 set-metadata <agentId>`
+- `--key <string>` — Metadata key (required)
+- `--value <hex|string>` — `0x`-hex bytes or plain string, UTF-8 encoded (required)
+- `--chain <key>` — EVM chain key (default `bsc`)
+- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--json` — Output as JSON
+
+### `erc8004 get-metadata <agentId>`
+- `--key <string>` — Metadata key (required)
+- `--chain <key>` — EVM chain key (default `bsc`)
+- `--json` — Output as JSON
+
+### `erc8004 show <agentId>`
+- `--chain <key>` — EVM chain key (default `bsc`)
+- `--json` — Output as JSON
+
+## BSC Testnet
+
+Pass `--chain bsctestnet` to operate against the BSC testnet deployment (`0x8004a818bfb912233c491871b3d84c89a494bd9e`, chain ID 97). The testnet key is not listed by `twak chains`.
+
+```bash
+twak erc8004 register --chain bsctestnet --uri ipfs://Qm… --json
+```

--- a/skills/wallet/references/erc8183.md
+++ b/skills/wallet/references/erc8183.md
@@ -1,0 +1,198 @@
+
+# ERC-8183 Agentic Commerce
+
+On-chain job escrows between AI agents on EVM chains. A **client** creates a job, funds an escrow in an ERC-20 payment token, and a **provider** (worker) submits a deliverable. Settlement releases the escrow to the provider or refunds the client. Three contracts work together:
+
+- **Commerce** (`AgenticCommerce`) — jobs, escrow, and the deliverable lifecycle.
+- **EvaluatorRouter** — routes settlement/disputes to a policy (optimistic model).
+- **OptimisticPolicy** — an optimistic dispute window with reject-voting.
+
+`erc8183` commands default to `--chain bsc`. Only `bsc` and `bsctestnet` have known deployments.
+
+## Deployments
+
+| Contract | `bsc` | `bsctestnet` |
+|----------|-------|--------------|
+| Commerce | `0xea4daa3100a767e86fded867729ae7446476eba6` | `0xa206c0517b6371c6638cd9e4a42cc9f02a33b0de` |
+| EvaluatorRouter | `0x51895229e12f9876011789b04f8698af06ccd6da` | `0xd7d36d66d2f1b608a0f943f722d27e3744f66f25` |
+| OptimisticPolicy | `0x9c01845705b3078aa2e8cff7520a6376fd766de5` | `0x4f4678d4439fec812ac7674bb3efb4c8f5fb78a6` |
+| Payment token (`U`, 18 dec) | `0xce24439f2d9c6a2289f741120fe202248b666666` | `0xc70B8741B8B07A6d61E54fd4B20f22Fa648E5565` |
+
+Budgets and escrow are denominated in the **payment token** (read it from `status` → `paymentToken`), not the native coin. The client wallet must hold ≥ the budget in that token before `fund`; gas is paid separately in the native coin.
+
+## Job lifecycle
+
+Status enum (from `status`): `Open → Funded → Submitted → Completed | Rejected | Expired`.
+
+There are two settlement models. Choose one at `create-job` time via the `evaluator`:
+
+### A. Direct evaluation (evaluator is a trusted address)
+
+```
+create-job → set-budget → fund → submit → complete (or reject)
+```
+
+The `evaluator` address decides the outcome: it calls `complete` (releases escrow to the provider) or `reject` (refunds the client). Simplest model; no Router/Policy involved.
+
+### B. Optimistic dispute (evaluator = the EvaluatorRouter)
+
+```
+create-job → set-budget → register-job → fund → submit → settle (after the dispute window)
+```
+
+For this model the job must be wired to the Router/Policy:
+
+- Set **both `--evaluator` and `--hook` to the EvaluatorRouter address** at `create-job`. A zero hook reverts `HookRequired()`; an evaluator that isn't the Router reverts `RouterNotEvaluator()` at `register-job`.
+- **`register-job` MUST run before `fund`** — funding with the Router as hook reverts `PolicyNotSet()` until a policy is registered.
+- After `submit`, anyone can `settle` once the dispute window elapses (releases escrow to the provider). The client may `dispute` within the window; voters `vote-reject`; reaching the reject quorum refunds the client. `mark-expired` finalises a past-expiry job to `Expired`.
+- In this model `complete`/`reject` are not caller-invoked — settlement runs through the Router/Policy.
+
+### Expiry constraints
+
+`--expires-at` is a unix timestamp (seconds). `create-job` requires it to be in the future and ≤ now + 365 days. Separately, `submit` requires `now ≤ expiredAt − disputeWindow` (the Policy's window: **7 days on `bsc`, 1 day on `bsctestnet`**), so a too-short expiry creates and funds fine but can't be submitted. Use roughly a 30-day expiry. After expiry, the client can `claim-refund`.
+
+## Commerce commands
+
+### Create a job
+
+```bash
+twak erc8183 create-job \
+  --provider <address> \
+  --evaluator <address> \
+  --expires-at <unix> \
+  --description <text> \
+  --hook <address> \
+  --json
+```
+
+Caller becomes the client. For the optimistic model set `--evaluator` and `--hook` to the EvaluatorRouter address (see model B). Output: `{ jobId, status: "Open", hash, chain, explorer }`.
+
+### Set / change the provider
+
+```bash
+twak erc8183 set-provider <jobId> --provider <address> --json
+```
+
+Client-only, allowed while the job is still `Open`. Output: `{ jobId, provider, hash, chain, explorer }`.
+
+### Set the budget
+
+```bash
+twak erc8183 set-budget <jobId> --amount <atomic> --json
+```
+
+`--amount` is in atomic units of the payment token (e.g. `1000000000000000000` = 1.0 of an 18-decimal token). Output: `{ jobId, amount, hash, chain, explorer }`.
+
+### Fund the escrow
+
+```bash
+twak erc8183 fund <jobId> --json
+```
+
+Two transactions: approves exactly the on-chain budget to the Commerce contract, then deposits it into escrow. The budget must be set first (else `VALIDATION_ERROR`). Output: `{ jobId, status: "Funded", approveHash, hash, chain, explorer }`.
+
+### Submit a deliverable
+
+```bash
+twak erc8183 submit <jobId> --deliverable <bytes32> --json
+```
+
+`--deliverable` is a `0x`-prefixed 32-byte commitment (e.g. a content hash). Output: `{ jobId, status: "Submitted", hash, chain, explorer }`.
+
+### Complete (direct-evaluator model)
+
+```bash
+twak erc8183 complete <jobId> --reason <bytes32> --json
+```
+
+Evaluator marks a submitted job complete, releasing the escrow to the provider. `--reason` is an optional bytes32 attestation (defaults to zero). Output: `{ jobId, status: "Completed", released, hash, chain, explorer }` (`released` = amount paid out, or `null`).
+
+### Reject (direct-evaluator model)
+
+```bash
+twak erc8183 reject <jobId> --reason <bytes32> --json
+```
+
+Refunds the client if the job was funded. `--reason` optional bytes32. Output: `{ jobId, status: "Rejected", refunded, hash, chain, explorer }`.
+
+### Claim a refund
+
+```bash
+twak erc8183 claim-refund <jobId> --json
+```
+
+Client claims the escrow back from an expired job. Output: `{ jobId, status: "Expired", refunded, hash, chain, explorer }`.
+
+### Job status (read-only)
+
+```bash
+twak erc8183 status <jobId> --json
+```
+
+Output: `{ jobId, status, client, provider, evaluator, description, budget, expiredAt, submittedAt, deliverable, hook, paymentToken, chain }` — `status` is the enum name, `budget`/`expiredAt`/`submittedAt` are decimal strings.
+
+## EvaluatorRouter commands (optimistic model)
+
+### Register a job with a policy
+
+```bash
+twak erc8183 register-job <jobId> --policy <address> --json
+```
+
+`--policy` defaults to the deployed OptimisticPolicy. Must run **before** `fund` in the optimistic model. Output: `{ jobId, policy, hash, chain, explorer }`.
+
+### Settle through the policy
+
+```bash
+twak erc8183 settle <jobId> --evidence <hex> --json
+```
+
+Settles a job via its registered policy after the dispute window. `--evidence` is optional opaque bytes (defaults to empty). Output: `{ jobId, hash, chain, explorer }`.
+
+### Mark expired (permissionless)
+
+```bash
+twak erc8183 mark-expired <jobId> --json
+```
+
+Finalises a registered job past its expiry to `Expired`. Output: `{ jobId, status: "Expired", hash, chain, explorer }`.
+
+## OptimisticPolicy commands
+
+### Raise a dispute (client)
+
+```bash
+twak erc8183 dispute <jobId> --json
+```
+
+Output: `{ jobId, hash, chain, explorer }`.
+
+### Vote to reject (voter)
+
+```bash
+twak erc8183 vote-reject <jobId> --json
+```
+
+Output: `{ jobId, hash, chain, explorer }`.
+
+## Options
+
+All write subcommands accept `--chain <key>` (default `bsc`; `bsctestnet` supported), `--password <pw>` (resolved from OS keychain / `TWAK_WALLET_PASSWORD` if omitted), and `--json`. `status` is read-only (no `--password`).
+
+## Common reverts
+
+The contracts use custom errors; a revert may surface as a raw 4-byte selector. The most common:
+
+- `0x55c45de1` `HookRequired()` — `create-job` with a zero hook (set `--hook` to the Router for the optimistic model)
+- `0xec43ea50` `RouterNotEvaluator()` — `register-job` when `evaluator` isn't the Router
+- `0x32d53d69` `PolicyNotSet()` — `fund` before `register-job` (optimistic model)
+- `0x15e5dd74` `SubmissionTooLate()` — `submit` after `expiredAt − disputeWindow`
+- `0xf7a0748c` `ExpiryTooShort()` / `0xb40b2a0e` `ExpiryTooLong()` — `--expires-at` not in `(now, now + 365d]`
+- `0x99b0fc87` `BudgetMismatch()` — on-chain budget changed between read and `fund`
+
+## BSC Testnet
+
+Pass `--chain bsctestnet` to use the testnet deployment (chain ID 97; addresses in the table above). Differences from mainnet:
+
+- The Policy `disputeWindow` is **1 day** (vs 7 days), so the submit floor is looser and optimistic `settle` unlocks after 1 day.
+- The payment token `U` on testnet has an `Ownable` `mint` — a non-owner wallet cannot self-mint and cannot swap for it on testnet, so the client wallet must be funded with `U` out-of-band before `fund`.

--- a/skills/wallet/references/send.md
+++ b/skills/wallet/references/send.md
@@ -33,6 +33,24 @@ Transfer native tokens or ERC-20 tokens across supported chains. Supports ENS na
 
 Password is auto-resolved from OS keychain. Use `--password <pw>` to override.
 
+## Selecting the chain & token
+
+Two equivalent ways to specify what to send:
+
+1. **By asset ID** (default) — `--token <assetId>`, no `--chain`. The chain is derived from the asset ID's coin ID:
+   ```bash
+   twak transfer --to 0x… --amount 1.5 --token c60 --json                  # native ETH
+   twak transfer --to 0x… --amount 100 --token c60_t0xA0b8…eB48 --json      # USDC on Ethereum
+   ```
+
+2. **By chain key** — `--chain <key>` plus an optional bare token contract address (omit `--token` for the native coin):
+   ```bash
+   twak transfer --to 0x… --amount 1.5 --chain base --json                          # native coin on Base
+   twak transfer --to 0x… --amount 100 --chain base --token 0x833589…2913 --json    # token by address on Base
+   ```
+
+Do not combine an asset ID with `--chain` (e.g. `--chain base --token c60`) — that is rejected. Use one form or the other.
+
 ## ENS & Human-Readable Names
 
 The `--to` field resolves ENS names automatically:
@@ -63,7 +81,8 @@ Decimals are resolved automatically via the API.
 
 - `--to <address>` — Destination address or ENS name (required)
 - `--amount <n>` — Amount in human-readable format (required)
-- `--token <assetId>` — Token asset ID (required)
+- `--token <assetIdOrAddress>` — Without `--chain`: the asset ID (e.g. `c60`, `c60_t0x…`) — required in this form. With `--chain`: a bare token contract address (`0x…`); omit it to send the native coin.
+- `--chain <key>` — Chain key (e.g. `base`, `ethereum`, `bsctestnet`). When set, `--token` is a token contract address. See **Selecting the chain & token** above.
 - `--confirm-to <address>` — Pin the expected resolved address. Transfer is rejected if ENS resolution returns a different address.
 - `--max-usd <n>` — Maximum allowed transfer value in USD (default: 10000). Transfer is rejected if value exceeds this.
 - `--skip-safety-check` — Bypass the USD value safety check
@@ -73,3 +92,17 @@ Decimals are resolved automatically via the API.
 ## Supported Chains
 
 Run `twak chains` for all supported chains and coin IDs.
+
+## BSC Testnet
+
+`--chain bsctestnet` targets BSC testnet (chain ID 97). This testnet key is intentionally **not** listed by `twak chains` — it is enabled only for a limited set of operations: ERC-20 transfer/approve/balance and ERC-8004 / ERC-8183 contract calls. Swaps, portfolio, market data, and onramp stay mainnet-only.
+
+```bash
+# Native tBNB transfer
+twak transfer --to 0x… --amount 0.01 --chain bsctestnet --json
+
+# ERC-20 token transfer (token by contract address)
+twak transfer --to 0x… --amount 1 --chain bsctestnet --token 0x… --json
+```
+
+The testnet wallet address is the same as the mainnet BSC address (`twak wallet address --chain bsc`); fund it from a BSC testnet faucet. Note: `twak wallet balance --chain bsctestnet` is **not** supported (the CLI balance command reads a mainnet data gateway). To read testnet balances, use the MCP `token_balance` tool with `chain: "bsctestnet"`, which queries the testnet RPC directly.

--- a/skills/wallet/references/setup.md
+++ b/skills/wallet/references/setup.md
@@ -128,3 +128,7 @@ Example entry:
 ```
 
 25+ chains are supported across EVM (eip155), Solana, Bitcoin (bip122), TRON, Cosmos, NEAR, Aptos, TON, and Sui namespaces.
+
+### BSC Testnet
+
+`bsctestnet` (BSC testnet, chain ID 97) is a special chain key that is **not** listed by `twak chains`. It is enabled only for ERC-20 transfer/approve/balance and ERC-8004 / ERC-8183 contract calls — not swaps, portfolio, market data, or onramp. Pass it via `--chain bsctestnet`. See `references/send.md` and `references/erc20.md` for usage.


### PR DESCRIPTION
Documents the additive `--chain` flag on `transfer` and `erc20 approve/revoke/allowance`, the new `bsctestnet` chain key, and the `erc8004` + `erc8183` command families — to match twak PR #149 (BSC testnet support + atomic ERC-8004 register).

- `send.md`: chain/token addressing modes (asset ID vs `--chain` + contract address) + a BSC testnet section
- `erc20.md`: `--chain` on all three subcommands + testnet example
- `setup.md`: note that `bsctestnet` is a special key intentionally not listed by `twak chains`
- `erc8004.md` (new): full `register` / `set-uri` / `set-metadata` / `get-metadata` / `show` reference — atomic `--metadata key=value` mints, `data:` inline URIs, the `0x`-hex/UTF-8 value encoding rule, and `bsc` + `bsctestnet` deployments
- `erc8183.md` (new): full Agentic Commerce reference — Commerce / EvaluatorRouter / OptimisticPolicy commands, the job lifecycle + both settlement models (direct-evaluator and optimistic dispute), payment-token escrow, expiry/dispute-window constraints, common reverts, and `bsc` + `bsctestnet` deployments
- `SKILL.md`: index rows for the new references

Coordinates the cached CLI contract with the new CLI semantics. Pairs with trustwallet/twak#149.