### PR TITLE
docs(wallet): v0.19.0 updates + full 1:1 accuracy pass against the CLI

### DIFF
--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -19,7 +19,7 @@ Read the reference that matches the user's task:
 |------|-----------|--------------|
 | Install, auth, env vars | `references/setup.md` | First time setup, "install twak", "configure API keys" |
 | List supported chains, chain keys | `references/setup.md` | "what chains are supported", "list chains", "show chain keys", "what is the chain key for X" |
-| Create wallet, keychain, sign | `references/wallet.md` | "create wallet", "keychain", "sign message", "wallet status" |
+| Create wallet, keychain, sign, register | `references/wallet.md` | "create wallet", "keychain", "sign message", "wallet status", "register wallet with backend" |
 | Balance, holdings, portfolio | `references/balance.md` | "check balance", "portfolio", "token holdings" |
 | Send tokens, ENS transfers | `references/send.md` | "send ETH", "transfer to", "vitalik.eth" |
 | Swap tokens, cross-chain | `references/swap.md` | "swap ETH for USDC", "bridge", "cross-chain swap" |
@@ -33,6 +33,20 @@ Read the reference that matches the user's task:
 | x402 micropayments | `references/x402.md` | "x402", "micropayment", "payment-gated API", "preview payment", "quote endpoint cost", "how much does this API charge" |
 | BNB Hack competition register/status | `references/compete.md` | "register for the competition", "BNB hack", "AI trading agent edition", "compete", "registration status" |
 | Register/manage ERC-8004 agent identities | `references/erc8004.md` | "register agent identity", "erc8004", "agent NFT", "agentURI", "agent metadata", "identity registry", "mint agent" |
-| Agent job escrows (ERC-8183 Agentic Commerce) | `references/erc8183.md` | "erc8183", "agentic commerce", "job escrow", "create job", "fund job", "submit deliverable", "settle job", "agent payment escrow", "evaluator router" |
+| Agent job escrows (ERC-8183 Agentic Commerce) | `references/erc8183.md` | "erc8183", "agentic commerce", "job escrow", "create job", "fund job", "submit deliverable", "settle job", "dispute policy", "policy-info", "agent payment escrow", "evaluator router" |
+| Run MCP / REST server for AI agents | MCP server section below | "MCP server", "twak serve", "connect an agent", "REST API" |
 
 Read `references/setup.md` alongside any other reference if the CLI isn't installed yet.
+
+## MCP server
+
+`twak serve` starts an MCP server on stdio exposing wallet actions to AI agents. Flags:
+
+- `--rest` — start a REST HTTP server instead of the MCP stdio server
+- `--port <n>` — REST server port (default `3000`)
+- `--host <host>` — REST bind host (default `127.0.0.1`; use `0.0.0.0` to expose externally)
+- `--password <password>` — wallet password (falls back to `TWAK_WALLET_PASSWORD` env var, then OS keychain)
+- `--auto-lock <minutes>` — auto-lock the wallet after N minutes of inactivity
+- `--wc-project-id <id>` — WalletConnect project ID (or set `WALLETCONNECT_PROJECT_ID`)
+- `--watch` — background watcher that fires DCA/limit automations; requires the local agent wallet (see `references/automations.md`)
+- `--watch-interval <duration>` — automation poll interval when `--watch` is set, e.g. `30s`, `5m`, `1h` (default 60s, min 5s)

--- a/skills/wallet/references/alerts.md
+++ b/skills/wallet/references/alerts.md
@@ -1,7 +1,9 @@
 
 # Price Alerts
 
-Set up price alerts that trigger when tokens reach target prices. Alerts are stored locally and checked on demand or by the watcher.
+Set up price alerts that trigger when tokens reach target prices. Alerts are stored locally in `~/.twak/alerts.json` and checked on demand or by the watcher.
+
+Alerts are **one-shot**: when an alert triggers (via `alert check` or `twak watch`), it is deactivated — `active` becomes `false` and `triggeredAt` is set. It is not deleted.
 
 ## Create an Alert
 
@@ -14,12 +16,18 @@ twak alert create --token USDC --chain bsc --above 1.1 --json
 twak alert create --token c60 --chain ethereum --below 2000 --json
 ```
 
+Exactly one of `--above` or `--below` is required — both or neither is a `VALIDATION_ERROR`. The price must be a positive number.
+
+Output: the full alert record `{ id, tokenId, chainKey, condition, targetPrice, createdAt, active }` (`condition` is `above` or `below`; triggered records also carry `triggeredAt`).
+
 ## List Alerts
 
 ```bash
 twak alert list --json
 twak alert list --active --json
 ```
+
+Output: array of alert records, each enriched with `tokenLabel` (resolved symbol) and `chainLabel` (chain key). `active: false` means the alert already triggered.
 
 ## Check Alerts
 
@@ -29,11 +37,24 @@ Check active alerts against current prices:
 twak alert check --json
 ```
 
+Output: `{ checked, triggered, alerts }` — `checked` and `triggered` are counts; `alerts` contains the triggered records, each with `currentPrice` added. Triggered alerts are deactivated (one-shot).
+
 ## Delete an Alert
 
 ```bash
-twak alert delete <alertId>
+twak alert delete <alertId> --json
 ```
+
+Output: `{ "success": true }`. Unknown id → `ALERT_NOT_FOUND`.
+
+## Errors
+
+On failure, alert commands emit `{ error, errorCode }` on stdout (with `--json`) and exit with code 1. Error codes:
+
+- `VALIDATION_ERROR` — both/neither of `--above`/`--below`, non-positive price, or token that can't be resolved without `--chain` (create)
+- `CHAIN_UNSUPPORTED` — unknown chain key (create)
+- `TOKEN_NOT_FOUND` — unknown token symbol on the given chain (create)
+- `ALERT_NOT_FOUND` — unknown alert id (delete)
 
 ## Continuous Monitoring
 
@@ -43,7 +64,12 @@ Use `twak watch` to continuously poll alerts and execute DCA/limit order automat
 twak watch                    # polls every 60s
 twak watch --interval 5m     # custom interval
 twak watch --dry-run         # check conditions without executing
+twak watch --json            # structured JSON output per tick
 ```
+
+`--interval` accepts `<number><s|m|h|d>` (e.g. `30s`, `5m`, `1h`, `1d`); a bare number means seconds. Minimum 5 seconds.
+
+Other flags: `--password <password>` (wallet password for executing swaps; falls back to the `TWAK_WALLET_PASSWORD` env var, then the OS keychain) and `--auto-lock <minutes>` (lock the wallet after N minutes of inactivity).
 
 See `references/automations.md` for DCA and limit order setup.
 

--- a/skills/wallet/references/automations.md
+++ b/skills/wallet/references/automations.md
@@ -5,6 +5,10 @@ Create recurring swaps (DCA) or conditional one-time swaps (limit orders) that e
 
 **Important:** Automations only execute while a watcher is polling — either a standalone `twak watch` process, or an MCP server started with `twak serve --watch`. Without one, rules are saved but never fire. If the watcher is stopped, automations are paused until it is started again.
 
+`automate add` requires exactly one of `--interval` (creates a DCA) or `--price` (creates a limit order) — both or neither is a `VALIDATION_ERROR`. Only EVM chains and Solana are supported; any other chain is rejected with `CHAIN_UNSUPPORTED` ("Use an EVM chain or Solana."). `--amount` must be a positive number.
+
+Output of `add`: the full automation record (see Storage below; `runCount` starts at 0).
+
 ## Create a DCA Automation
 
 Dollar-cost averaging — swap a fixed amount of the source token (`--from`) on a recurring schedule. `--amount` is always denominated in the source token.
@@ -26,7 +30,7 @@ twak automate add \
   --json
 ```
 
-Intervals accept any `<number><s|m|h>` format (e.g. `30s`, `5m`, `1h`, `24h`). Minimum 5s.
+Intervals accept `<number><s|m|h|d>` (e.g. `30s`, `5m`, `1h`, `7d`); decimals are allowed and a bare number means seconds. Minimum 5s.
 
 ## Create a Limit Order
 
@@ -61,7 +65,7 @@ twak automate add \
 
 | Flag | Description |
 |------|-------------|
-| `--max-runs <n>` | Stop after N executions. Automation deactivates automatically. |
+| `--max-runs <n>` | Stop after N executions (positive integer). Automation deactivates automatically. |
 | `--expires <date>` | Expiry date in ISO 8601 format (e.g. `2026-04-01`). Automation deactivates after this date. |
 | `--chain <chain>` | Chain key (default: `ethereum`). |
 | `--json` | Structured JSON output. |
@@ -72,13 +76,27 @@ twak automate add \
 twak automate list --json
 ```
 
+Output: array of automation records, each enriched with computed `nextRunAt` (ISO timestamp) and `nextRunIn` (e.g. `in 3h`, `overdue`). Both are populated for DCA automations only and are `null` for limit orders.
+
 ## Pause / Resume / Delete
 
 ```bash
-twak automate pause <id>
-twak automate resume <id>
+twak automate pause <id> --json
+twak automate resume <id> --json
 twak automate delete <id>
 ```
+
+`pause`/`resume` output the updated automation record. `delete` emits **no JSON on success** even with `--json` — the confirmation goes to stderr only; errors still emit `{ error, errorCode }` on stdout. Unknown id → `AUTOMATION_NOT_FOUND`.
+
+When a limit order fires, it is deactivated (`active: false`), not deleted — `automate resume <id>` re-arms it.
+
+## Errors
+
+On failure, automate commands emit `{ error, errorCode }` on stdout (with `--json`) and exit with code 1. Error codes:
+
+- `VALIDATION_ERROR` — `--interval`/`--price` both or neither, non-positive `--amount`, interval below 5s, non-positive-integer `--max-runs`, invalid `--expires` date
+- `CHAIN_UNSUPPORTED` — unknown chain key, or a non-EVM/non-Solana chain (add)
+- `AUTOMATION_NOT_FOUND` — unknown automation id (delete/pause/resume)
 
 ## Execute Automations
 
@@ -91,7 +109,9 @@ twak watch --dry-run         # check conditions without executing
 twak watch --json            # structured output
 ```
 
-`watch` requires the wallet password to execute swaps. Password is auto-resolved from the OS keychain if configured.
+`--interval` accepts `<number><s|m|h|d>`; a bare number means seconds. Minimum 5 seconds. `--auto-lock <minutes>` locks the wallet after N minutes of inactivity.
+
+`watch` requires the wallet password to execute swaps. Resolution order: `--password <password>` flag → `TWAK_WALLET_PASSWORD` env var → OS keychain.
 
 ## Running under the MCP server
 

--- a/skills/wallet/references/balance.md
+++ b/skills/wallet/references/balance.md
@@ -3,13 +3,15 @@
 
 Query native balances, token holdings, and full portfolio with USD values across all supported chains.
 
+On error, all commands emit `{ error, errorCode }` on stdout (with `--json`) and exit with code 1.
+
 ## Prerequisites
 
 - Authenticated (`twak auth status`)
 
 ## Own Wallet Balance
 
-Native token balance on a specific chain (password auto-resolved from OS keychain):
+Native balance + token holdings per chain (password auto-resolved from OS keychain):
 
 ```bash
 twak wallet balance --chain ethereum --json
@@ -19,10 +21,18 @@ twak wallet balance --all --json
 twak wallet balance --chain ethereum --no-tokens --json  # native only, skip token lookup
 ```
 
-- `--all` — Show balances across all chains with funds
+- `--chain <key>` — Single chain (chain key, e.g. `bsc`)
+- `--all` — All chains with funds. Exactly one of `--chain`/`--all` is required; passing both or neither → `VALIDATION_ERROR`
 - `--no-tokens` — Skip token balance lookup (faster, native balance only)
+- `--password <pw>` — Wallet password (falls back to keychain / `TWAK_WALLET_PASSWORD`)
 
-Output: `{ chain, address, symbol, available, staked, pending, total }`
+Output: `{ chain, address, symbol, available, staked?, total, totalUsd, tokens }`
+
+- `chain` — the chain key you passed (e.g. `bsc`)
+- `staked` — omitted when zero
+- `totalUsd` — number or `null` when no fiat value available
+- `tokens` — array of `{ symbol, contract, balance }` (zero balances excluded)
+- With `--all`, output is an ARRAY of these objects, filtered to chains with a non-zero native balance or tokens
 
 ## Full Portfolio
 
@@ -35,24 +45,28 @@ twak wallet portfolio --chains ethereum,base,bsc,solana --json
 
 Default chains: ethereum, arbitrum, optimism, polygon, bsc, avalanche, base, fantom, linea, scroll, zksync, blast, sonic, celo, aurora, solana, bitcoin, litecoin, dogecoin, tron, cosmos, near, aptos, ton, sui.
 
+There is no `twak holdings` command — use `twak wallet balance` (native + token holdings per chain) or `twak wallet portfolio` for the agent wallet, or `twak balance --token <contract>` for a single token on any address.
+
 ## Any Address Balance
 
-Query native balance for any address (no wallet required):
+Query balance for any address (no wallet required). One of `--coin`/`--chain` is required, else `VALIDATION_ERROR`:
 
 ```bash
-twak balance --address <addr> --coin 60 --json        # Ethereum
-twak balance --address <addr> --coin 501 --json       # Solana
-twak balance --address <addr> --coin 20000714 --json  # BSC
+twak balance --address <addr> --coin 60 --json        # Ethereum (SLIP44 coin ID)
+twak balance --address <addr> --chain bsc --json      # chain key alternative to --coin
 twak balance --address <addr> --coin 0 --json         # Bitcoin
+twak balance --address <addr> --chain ethereum --token 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 --json  # ERC-20
 ```
 
-## Token Holdings
+- `--coin <coinId>` — SLIP44 coin ID (native token)
+- `--chain <key>` — Chain key (alternative to `--coin`)
+- `--token <address>` — Token contract address (for ERC-20 balances)
 
-List all token holdings for an address:
+Output: `{ address, chain, symbol, token?, available, staked?, total, totalUsd, raw }`
 
-```bash
-twak holdings --address <addr> --chain ethereum --json
-```
+- `chain` — the chain's internal id, which can differ from the chain key (e.g. `smartchain` for BSC)
+- `token` — present only when `--token` was passed
+- `staked` — omitted when zero; `totalUsd` — number or `null`
 
 ## Search Tokens
 
@@ -61,7 +75,11 @@ Find tokens by name, symbol, or contract address:
 ```bash
 twak search "USDC" --limit 10 --json
 twak search "pepe" --json
+twak search "USDC" --networks ethereum,bsc --json
 ```
+
+- `--networks <names>` — Comma-separated chain names or numeric coin IDs; unknown name → `CHAIN_UNSUPPORTED`
+- `--limit <n>` — Max results (default: 10)
 
 ## Asset Info
 

--- a/skills/wallet/references/compete.md
+++ b/skills/wallet/references/compete.md
@@ -40,7 +40,7 @@ Registers `participant` on-chain. The command is idempotent and validates the wi
 Success output: `{ registered: true, participant, deadline, hash, chain, explorer }`
 
 - `hash` — registration transaction hash
-- `explorer` — BscScan URL for the transaction
+- `explorer` — block-explorer URL for the transaction (the chain's explorer; BscScan, since `chain` is always `bsc`)
 
 ## Options
 
@@ -51,4 +51,4 @@ Both `compete status` and `compete register` accept:
 
 ## Registry Contract
 
-Registration targets the competition registry deployed on BSC at `0x212c61B9B72C95d95BF29CF032F5E5635629Aed5`.
+Registration targets the competition registry deployed on BSC at `0x212c61B9B72C95d95BF29CF032F5E5635629Aed5`. Set the `COMPETITION_REGISTRY_ADDRESS` environment variable to override this address for both subcommands (e.g. to target a test deployment); the chain stays `bsc`.

--- a/skills/wallet/references/erc20.md
+++ b/skills/wallet/references/erc20.md
@@ -15,7 +15,7 @@ Do not combine an asset ID with `--chain` — that is rejected. Native coins hav
 ## Prerequisites
 
 - Authenticated (`twak auth status`)
-- Agent wallet created (`twak wallet create --password <pw>`)
+- Agent wallet created (`twak wallet create --password <pw>`) — needed for `approve` and `revoke` only; `allowance` is a read and requires no wallet or password
 
 ## Approve a Spender
 
@@ -27,7 +27,7 @@ twak erc20 approve \
   --json
 ```
 
-`--amount` is in the token's smallest unit (e.g. wei for ETH-based tokens), or `unlimited` for max approval.
+`--amount` is in the token's own smallest unit — decimals vary per token (e.g. `100000000` = 100 USDC at 6 decimals; an 18-decimal token would need `100000000000000000000`). Or pass `unlimited` for max approval (requires `--confirm-unlimited`).
 
 Examples:
 
@@ -45,7 +45,7 @@ twak erc20 approve \
   --amount unlimited --confirm-unlimited --json
 ```
 
-Output: `{ hash, chain, owner, spender, token, amount, explorer }`
+Output: `{ hash, chain, owner, spender, token, amount, explorer }` — `chain` is the resolved chain key, `owner` the wallet address, `token` echoes the raw `--token` input (asset ID or contract address, whichever you passed), `amount` echoes the literal input (including the string `"unlimited"`, not the expanded max uint256), `explorer` is the explorer tx URL or `''` when the chain has no explorer mapping.
 
 ## Revoke Approval
 
@@ -58,6 +58,8 @@ twak erc20 revoke \
   --json
 ```
 
+Output: `{ hash, chain, owner, spender, token, explorer }` — same keys as `approve` minus `amount`; `token` echoes the raw `--token` input, `explorer` is `''` when the chain has no explorer mapping.
+
 ## Check Allowance
 
 ```bash
@@ -68,7 +70,7 @@ twak erc20 allowance \
   --json
 ```
 
-Output: `{ token, owner, spender, allowance }`
+Output: `{ token, owner, spender, allowance }` — `token`, `owner`, `spender` echo the inputs; `allowance` is a decimal string in the token's smallest unit (e.g. `"100000000"`).
 
 ## Options
 
@@ -78,14 +80,14 @@ Output: `{ token, owner, spender, allowance }`
 - `--amount <n>` — Amount in smallest unit, or `unlimited` (required)
 - `--chain <key>` — Chain key (e.g. `base`, `bsctestnet`). When set, `--token` is the token contract address.
 - `--confirm-unlimited` — Required when using `--amount unlimited` to acknowledge the risk
-- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--password <pw>` — Wallet password (falls back to `TWAK_WALLET_PASSWORD` env var, then OS keychain)
 - `--json` — Output as JSON
 
 ### `erc20 revoke`
 - `--token <assetIdOrAddress>` — Without `--chain`: ERC-20 asset ID. With `--chain`: the token contract address (required)
 - `--spender <address>` — Spender to revoke (required)
 - `--chain <key>` — Chain key (e.g. `base`, `bsctestnet`). When set, `--token` is the token contract address.
-- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--password <pw>` — Wallet password (falls back to `TWAK_WALLET_PASSWORD` env var, then OS keychain)
 - `--json` — Output as JSON
 
 ### `erc20 allowance`
@@ -94,6 +96,16 @@ Output: `{ token, owner, spender, allowance }`
 - `--spender <address>` — Spender address (required)
 - `--chain <key>` — Chain key (e.g. `base`, `bsctestnet`). When set, `--token` is the token contract address.
 - `--json` — Output as JSON
+
+## Errors
+
+With `--json`, errors emit a single `{ error, errorCode }` object to stdout and exit with code 1.
+
+| errorCode | Trigger |
+|---|---|
+| `VALIDATION_ERROR` | Asset ID (`c…`) combined with `--chain`; malformed token ID; `--amount unlimited` without `--confirm-unlimited`; invalid contract address inside the asset ID (`allowance`) |
+| `NOT_ERC20` | Asset ID without a `_t<address>` part — native coins have no allowance |
+| `CHAIN_UNSUPPORTED` | Unknown `--chain` key, or unsupported coin ID in the asset ID |
 
 ## Safety Notes
 

--- a/skills/wallet/references/erc8004.md
+++ b/skills/wallet/references/erc8004.md
@@ -10,13 +10,14 @@ On-chain registry of AI-agent identities on EVM chains. Registering mints an NFT
 - `bsc` — `0x8004a169fb4a3325136eb29fa0ceb6d2e539a432`
 - `bsctestnet` — `0x8004a818bfb912233c491871b3d84c89a494bd9e` (chain ID 97; not listed by `twak chains`)
 
-For any other EVM chain, set `ERC8004_REGISTRY_ADDRESS=0x…` to target a custom deployment. ERC-8004 is EVM-only: a non-EVM chain, or an EVM chain with no known deployment and no env override, fails with `CHAIN_UNSUPPORTED`.
+For any other EVM chain that twak already knows (listed by `twak chains`), set `ERC8004_REGISTRY_ADDRESS=0x…` to target a custom deployment. The override does not add new chains — an unrecognized `--chain` key fails with `CHAIN_UNSUPPORTED` (`Unknown chain: "…"`) before the override is read. ERC-8004 is EVM-only: a non-EVM chain, or an EVM chain with no known deployment and no env override, also fails with `CHAIN_UNSUPPORTED`.
 
 ## Metadata value encoding
 
 Every metadata **value** (`register --metadata`, `set-metadata --value`) is encoded by the same rule:
 
-- a `0x`-prefixed hex string is sent as raw bytes — `0x01` → byte `0x01`
+- a valid `0x`-prefixed even-length hex string is sent as raw bytes — `0x01` → byte `0x01` (a `0X` prefix is accepted and canonicalized to `0x`)
+- a `0x`-prefixed string that is **not** valid even-length hex fails with `VALIDATION_ERROR` — it is never silently UTF-8 encoded; drop the `0x` prefix to send it as a string
 - any other string is UTF-8 encoded — `twak` → `0x7477616b`
 
 Reads (`get-metadata`) return the raw on-chain bytes as a `0x`-hex string; an unset key returns `0x`.
@@ -126,6 +127,14 @@ Output: `{ agentId, owner, agentWallet, agentURI, chain }` — `agentWallet` is 
 ### `erc8004 show <agentId>`
 - `--chain <key>` — EVM chain key (default `bsc`)
 - `--json` — Output as JSON
+
+## Errors
+
+With `--json`, failures print `{ error, errorCode }` to stdout and exit with code 1.
+
+- `VALIDATION_ERROR` — `<agentId>` is not a decimal integer string (checked before any network call); a `--metadata` pair is not `key=value`; a `0x`-prefixed value is not valid even-length hex
+- `CHAIN_UNSUPPORTED` — unrecognized `--chain` key (`Unknown chain: "…"`); non-EVM chain; or EVM chain with no known deployment and no `ERC8004_REGISTRY_ADDRESS` override
+- `TX_FAILED` — `register` transaction confirmed but emitted no `Registered` event; the message includes the tx hash
 
 ## BSC Testnet
 

--- a/skills/wallet/references/erc8183.md
+++ b/skills/wallet/references/erc8183.md
@@ -86,18 +86,18 @@ twak erc8183 set-budget <jobId> --amount <atomic> --json
 ### Fund the escrow
 
 ```bash
-twak erc8183 fund <jobId> --json
+twak erc8183 fund <jobId> [--expected-budget <atomic>] --json
 ```
 
-Two transactions: approves exactly the on-chain budget to the Commerce contract, then deposits it into escrow. The budget must be set first (else `VALIDATION_ERROR`). Output: `{ jobId, status: "Funded", approveHash, hash, chain, explorer }`.
+Two transactions: approves exactly the budget (the on-chain value, or the `--expected-budget` pin) to the Commerce contract, then deposits it into escrow. The budget must be set first (else `VALIDATION_ERROR`). `--expected-budget` pins the amount: the contract's `BudgetMismatch()` guard reverts if the on-chain budget differs, closing the race between reading the budget and funding; omitted, twak reads the current on-chain budget and funds that. Zero or non-numeric values fail fast with `VALIDATION_ERROR`. Output: `{ jobId, status: "Funded", approveHash, hash, chain, explorer }`.
 
 ### Submit a deliverable
 
 ```bash
-twak erc8183 submit <jobId> --deliverable <bytes32> --json
+twak erc8183 submit <jobId> --deliverable <bytes32> [--opt-params <hex>] --json
 ```
 
-`--deliverable` is a `0x`-prefixed 32-byte commitment (e.g. a content hash). Output: `{ jobId, status: "Submitted", hash, chain, explorer }`.
+`--deliverable` is a `0x`-prefixed 32-byte commitment (e.g. a content hash). In the optimistic model, pass the deliverable manifest in `--opt-params` — the Router forwards it to the policy, which re-emits it in the `JobInitialised` event where off-chain evaluators read it (e.g. hex-encoded `{"deliverable_url":"ipfs://…"}`). A submit without it emits empty optParams, so evaluators cannot locate the deliverable. Output: `{ jobId, status: "Submitted", hash, chain, explorer }`.
 
 ### Complete (direct-evaluator model)
 
@@ -175,13 +175,23 @@ twak erc8183 vote-reject <jobId> --json
 
 Output: `{ jobId, hash, chain, explorer }`.
 
+### Policy info (read-only)
+
+```bash
+twak erc8183 policy-info <jobId> --json
+```
+
+Reads the job's registered policy via the Router (falling back to the deployed OptimisticPolicy before `register-job`, so pre-flight reads like `disputeWindow` still work). Use it to check `settle` timing and dispute state instead of probing with reverting writes. Output: `{ jobId, policy, registered, disputeWindow, submittedAt, disputed, rejectVotes, voteQuorum, quorumSnapshot, settleableAt, chain }` — `registered`/`disputed` are booleans, the numeric fields are decimal strings, and `settleableAt` (`submittedAt + disputeWindow`, the moment optimistic `settle` unlocks) is `null` until a deliverable is submitted.
+
 ## Options
 
-All write subcommands accept `--chain <key>` (default `bsc`; `bsctestnet` supported), `--password <pw>` (resolved from OS keychain / `TWAK_WALLET_PASSWORD` if omitted), and `--json`. `status` is read-only (no `--password`).
+All write subcommands accept `--chain <key>` (default `bsc`; `bsctestnet` supported), `--password <pw>` (resolved from OS keychain / `TWAK_WALLET_PASSWORD` if omitted), and `--json`. `status` and `policy-info` are read-only (no `--password`).
+
+The six Commerce writes (`set-provider`, `set-budget`, `fund`, `submit`, `complete`, `reject`) also accept `--opt-params <hex>` — raw bytes passed through to the contract's trailing `optParams` parameter (`0x`-prefixed, even-length hex; defaults to empty). Invalid hex fails fast with `VALIDATION_ERROR` before any transaction. Only `submit` carries protocol-meaningful content (see above); on the others it is an extension point.
 
 ## Common reverts
 
-The contracts use custom errors; a revert may surface as a raw 4-byte selector. The most common:
+The contracts use custom errors; a revert surfaces the raw 4-byte selector in the error output, e.g. `{"error": "execution reverted: 0x32d53d69", "errorCode": "TX_FAILED"}`. The most common:
 
 - `0x55c45de1` `HookRequired()` — `create-job` with a zero hook (set `--hook` to the Router for the optimistic model)
 - `0xec43ea50` `RouterNotEvaluator()` — `register-job` when `evaluator` isn't the Router

--- a/skills/wallet/references/history.md
+++ b/skills/wallet/references/history.md
@@ -1,7 +1,9 @@
 
 # Transaction History
 
-Query transaction history and look up individual transactions with explorer URLs.
+Query transaction history and look up individual transactions by hash.
+
+On error, both commands emit `{ error, errorCode }` on stdout (with `--json`) and exit with code 1. Unknown `--chain` values → `CHAIN_UNSUPPORTED`.
 
 ## Prerequisites
 
@@ -17,36 +19,47 @@ twak history --address <addr> --chain solana --json
 twak history --address <addr> --chain bsc --from 2025-01-01 --to 2025-02-01 --json
 ```
 
+Single-chain rows may include a computed `usdValue` field (native amount × current price; omitted when not computable).
+
 ## Transaction Details
 
-Look up a specific transaction by hash (includes explorer URL):
+Look up a specific transaction by hash:
 
 ```bash
 twak tx <hash> --chain ethereum --json
 twak tx <hash> --chain solana --json
 ```
 
+Two output shapes depending on whether a wallet address is available:
+
+- Wallet available (`--address` given, or agent wallet unlocks): on-chain RPC lookup → `{ hash, chain, confirmed, pending, failed, error?, meta? }`
+- No wallet: txhub API fallback → `{ id, hash, chain, type, status, from, to, amount, fee, date, metadata? }`
+
 ## Own Wallet History
 
-If `--address` is omitted and an agent wallet exists, the address is auto-detected:
+Single-chain mode (`--chain` given): if `--address` is omitted, the address is auto-detected from the agent wallet:
 
 ```bash
 twak history --chain ethereum --json                    # auto-detects wallet address
 twak history --chain ethereum --json --password <pw>    # explicit password if no keychain
 ```
 
+Bulk mode (no `--chain`): queries all chains using addresses derived from the stored agent wallet — requires a wallet and password, and `--address` is IGNORED. To query an arbitrary address, always pass `--chain`.
+
 ## Options
 
 ### `history`
-- `--address <addr>` — Wallet address (auto-detected from agent wallet if omitted)
+- `--address <addr>` — Wallet address (single-chain mode only; auto-detected from agent wallet if omitted; ignored in bulk mode)
 - `--chain <chainKey>` — Chain key (omit for bulk history across all chains)
 - `--limit <n>` — Max results (default: 20)
 - `--from <date>` — Start date (YYYY-MM-DD)
 - `--to <date>` — End date (YYYY-MM-DD)
-- `--password <pw>` — Wallet password (for auto-detecting address when `--address` is omitted)
+- `--password <pw>` — Wallet password (for deriving addresses when `--address` is omitted or in bulk mode)
 - `--json` — Output as JSON
 
 ### `tx`
 - First argument: transaction hash (required)
 - `--chain <chainKey>` — Chain key (required)
+- `--address <addr>` — Wallet address for the on-chain lookup (auto-detected from agent wallet if omitted; without either, falls back to the txhub record)
+- `--password <pw>` — Wallet password (for auto-detecting address)
 - `--json` — Output as JSON

--- a/skills/wallet/references/market.md
+++ b/skills/wallet/references/market.md
@@ -3,9 +3,9 @@
 
 Query token prices, trending tokens by category, and featured DApps. All commands support `--json`.
 
-## Token Price
+On error, all commands emit `{ error, errorCode }` on stdout (with `--json`) and exit with code 1.
 
-Chain is auto-detected from native token symbols:
+## Token Price
 
 ```bash
 twak price ETH --json
@@ -13,6 +13,29 @@ twak price BNB --json                          # auto-detects bsc
 twak price SOL --json
 twak price USDC --chain ethereum --json
 ```
+
+Output: `{ token, chain, priceUsd }`
+
+Chain auto-detect (when `--chain` is omitted), in order: token matches a chain name (e.g. `solana`) → token matches a chain's native symbol (ETH→ethereum, BNB→bsc) → token is a well-known token mapped to its home chain (OP→optimism, ARB→arbitrum) → silently defaults to `ethereum`. Pass `--chain` explicitly for tokens on other chains. Unknown `--chain` → `CHAIN_UNSUPPORTED`.
+
+### Price History
+
+```bash
+twak price ETH --history --json          # default period: week
+twak price BNB --history month --json    # hour, day, week, month, year, all
+```
+
+Adds a `history` array of `{ price, date }` to the output: `{ token, chain, priceUsd, history }`.
+
+### Batch Prices
+
+Comma-separated tokens fetch in one call:
+
+```bash
+twak price ETH,BNB,SOL,USDC --json
+```
+
+Output: array of `{ token, chain, priceUsd }` — `priceUsd` is `null` for tokens the price API couldn't resolve.
 
 ## Trending Tokens
 
@@ -47,18 +70,25 @@ twak trending --category bonk --json
 twak trending --category memes --sort volume --limit 10 --json
 ```
 
+Results are deduplicated by symbol — when the same symbol appears multiple times, the entry with the highest market cap is kept.
+
 ## DApps & Protocols
 
-Browse featured DApps and on-chain protocols:
+Browse DeFi protocols and DApps (data from DeFi Llama):
 
 ```bash
-twak dapps --json
-twak dapps --category defi --json
-twak dapps --category dex --json
-twak dapps --category nft --json
-twak dapps --category lending --json
-twak dapps --category gaming --json
+twak dapps --json                                # top by TVL
+twak dapps --categories --json                   # list available category names
+twak dapps --category Lending --json
+twak dapps --category "Liquid Staking" --json
+twak dapps --search aave --json                  # search by name, symbol, or category
+twak dapps --limit 50 --json
 ```
+
+- `--category <name>` — Case-insensitive SUBSTRING match against DeFi Llama category names, NOT an enum. Beware: `defi` matches only the "CeDeFi" category. Use real category names — e.g. Lending, Dexs, Liquid Staking, Bridge, Yield — and run `twak dapps --categories` to list all available values.
+- `--search <query>` — Matches name substring, exact symbol, or category substring
+- `--categories` — List available category names
+- `--limit <n>` — Max results (default: 20)
 
 ## Token Search
 

--- a/skills/wallet/references/onramp.md
+++ b/skills/wallet/references/onramp.md
@@ -3,6 +3,10 @@
 
 Buy crypto with fiat (onramp) or sell crypto for fiat (offramp) through third-party providers. Quotes are aggregated; the user completes KYC and payment in the provider's hosted browser flow. Available providers depend on the user's region.
 
+On failure, commands with `--json` emit `{ error, errorCode }` on stdout and exit 1.
+
+All commands accept `--password <pw>`. A wallet password is needed whenever `--wallet` is omitted (the default path — the address is derived from your stored wallet). Resolution order: `--password` → `TWAK_WALLET_PASSWORD` env var → OS keychain.
+
 ## Prerequisites
 
 - Authenticated (`twak auth status`)
@@ -24,6 +28,8 @@ The destination address defaults to your stored wallet's address on the asset's 
 
 Quotes are sorted lowest-spread-first: `quotes[0]` is the provider giving the most crypto for the same fiat input. Each row has a `vsBestPct` field — `0` for the best, positive for worse (e.g. `vsBestPct: 8.23` means this quote gives 8.23% less crypto than the best one in the same response).
 
+`quote --json` output is an array of rows: `{ quoteId, cryptoAmount, cryptoCurrency, fiatAmount, fiatCurrency, provider, paymentMethod, vsBestPct }`. Buy quotes are unfiltered — the provider lineup is region-dependent. `buy --json` output: `{ url }` (`url` may be absent if the gateway returns none).
+
 After payment completes (5–30 min for card, 1–3 business days for bank transfer), check your balance:
 
 ```bash
@@ -37,12 +43,14 @@ twak wallet balance --chain ethereum --json
 - `--asset <id>` — Asset ID, e.g. `c60` for ETH, `c20000714` for BNB (required)
 - `--currency <code>` — Fiat currency (default: USD)
 - `--wallet <address>` — Override the derived destination address
+- `--password <pw>` — Wallet password (only needed when `--wallet` is omitted)
 - `--json` — Output as JSON
 
 `twak onramp buy`:
 - `--quote-id <id>` — Quote ID from `onramp quote` (required)
 - `--asset <id>` — Required when `--wallet` is omitted (used to derive your address)
 - `--wallet <address>` — Override the derived destination address
+- `--password <pw>` — Wallet password (only needed when `--wallet` is omitted)
 - `--json` — Output as JSON
 
 ## Offramp (Sell Crypto)
@@ -63,6 +71,10 @@ twak onramp sell-confirm \
 
 Sell quotes are sorted lowest-spread-first: `quotes[0]` is the provider returning the most fiat for the same crypto input. The `vsBestPct` field works the same way as on buy quotes (`0` for the best, positive for worse).
 
+Sell quotes are filtered to MoonPay only — other providers route signing through a Trust Wallet mobile deeplink, which can't be completed from CLI/agent contexts. (Buy quotes are unfiltered.)
+
+`sell-quote --json` output is an array of rows: `{ quoteId, cryptoAmount, cryptoCurrency, fiatAmount, fiatCurrency, provider, isRecommended, vsBestPct }` — same as buy-quote rows but with `isRecommended` instead of `paymentMethod`. `sell --json` output: `{ url }` (`url` may be absent if the gateway returns none). `sell-confirm --json` output: `{ hash, chain, from, to, amount, asset, memo, quoteId, explorer }`.
+
 ### Offramp options
 
 `twak onramp sell-quote`:
@@ -71,12 +83,14 @@ Sell quotes are sorted lowest-spread-first: `quotes[0]` is the provider returnin
 - `--currency <code>` — Fiat currency (default: USD)
 - `--method <method>` — Payout method: `ANY`, `card`, `bank_transfer` (default: `ANY`)
 - `--wallet <address>` — Override the derived source address
+- `--password <pw>` — Wallet password (only needed when `--wallet` is omitted)
 - `--json` — Output as JSON
 
 `twak onramp sell`:
 - `--quote-id <id>` — Quote ID from `sell-quote` (required)
 - `--asset <id>` — Required when `--wallet` is omitted
 - `--wallet <address>` — Override the derived source address
+- `--password <pw>` — Wallet password (only needed when `--wallet` is omitted)
 - `--json` — Output as JSON
 
 `twak onramp sell-confirm`:
@@ -90,9 +104,11 @@ Sell quotes are sorted lowest-spread-first: `quotes[0]` is the provider returnin
 - `--password <pw>` — Wallet password (resolved from keychain if omitted)
 - `--json` — Output as JSON
 
+`sell-confirm` error codes: `VALIDATION_ERROR` (bad asset ID / amount / `--max-usd`), `CHAIN_UNSUPPORTED` (asset's coin type not supported), `USD_LIMIT_EXCEEDED` (payout value above the `--max-usd` cap).
+
 ## Safety
 
-- `sell-confirm` rejects payouts above `--max-usd` (default $10,000); warns above $1,000.
+- `sell-confirm` rejects payouts above `--max-usd` (default $10,000) with `USD_LIMIT_EXCEEDED`; warns above $1,000. The cap is **best-effort**: it depends on a live USD price lookup — if the lookup fails the command warns on stderr and proceeds anyway; if no positive price is available it proceeds silently. Do not rely on `--max-usd` as the sole guard against an oversized payout.
 - The deposit address shown by the provider is **not under your control** — verify it byte-for-byte against what the provider displayed before broadcasting.
 - The browser flow has no access to your keys; it only collects KYC and reveals the deposit address. Signing always happens locally via `sell-confirm`.
 - `--memo` is required on chains like XRP, Cosmos, Stellar, BNB Beacon — omitting it can make funds unrecoverable.

--- a/skills/wallet/references/send.md
+++ b/skills/wallet/references/send.md
@@ -31,7 +31,9 @@ Transfer native tokens or ERC-20 tokens across supported chains. Supports ENS na
    twak transfer --to <address> --amount <n> --token <assetId> --json
    ```
 
-Password is auto-resolved from OS keychain. Use `--password <pw>` to override.
+Password resolution order: `--password` flag → `TWAK_WALLET_PASSWORD` env var → OS keychain. Fails with an error if none is set. Passing `--password` prints a shell-history warning to stderr.
+
+Success output: `{ hash, chain, from, to, amount, token, explorer }` — `hash` is the transaction hash, `chain` the resolved chain key, `to` the resolved destination address, `amount` echoes the input string, `token` is the resolved asset ID (`c{coinId}` or `c{coinId}_t0x…` form, even when you passed `--chain` + contract address), `explorer` is the explorer tx URL or `''` when the chain has no explorer mapping.
 
 ## Selecting the chain & token
 
@@ -53,12 +55,14 @@ Do not combine an asset ID with `--chain` (e.g. `--chain base --token c60`) — 
 
 ## ENS & Human-Readable Names
 
-The `--to` field resolves ENS names automatically:
+Any `--to` value containing a dot is resolved via Trust's naming API (naming.trustwallet.com) — this covers ENS-style names (`.eth`, `.crypto`, …) but is not an on-chain ENS lookup. Resolution failure → `ENS_NOT_FOUND`.
 
 ```bash
 twak transfer --to vitalik.eth --amount 0.01 --token c60 --json
 twak transfer --to myname.crypto --amount 100 --token c60_t0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 --json
 ```
+
+`--confirm-to <address>` pins the expected resolved address: if resolution changed the address and the result differs from the pin (case-insensitive compare), the transfer fails with `ENS_MISMATCH`. The pin is only checked when resolution actually changed the input — passing a raw `0x…` address with a non-matching `--confirm-to` is not rejected.
 
 ## Amount Format
 
@@ -70,7 +74,7 @@ Amounts are human-readable (not smallest unit):
 --amount 0.001     # 0.001 BTC
 ```
 
-Decimals are resolved automatically via the API.
+Decimals resolution order: `--decimals` override → token-search result → known-token registry. If none yields a value, the transfer fails with `VALIDATION_ERROR` ("Could not determine decimals…") — pass `--decimals <n>` for tokens the search/registry doesn't know. Decimals are never silently defaulted to 18.
 
 ## Asset IDs
 
@@ -83,11 +87,34 @@ Decimals are resolved automatically via the API.
 - `--amount <n>` — Amount in human-readable format (required)
 - `--token <assetIdOrAddress>` — Without `--chain`: the asset ID (e.g. `c60`, `c60_t0x…`) — required in this form. With `--chain`: a bare token contract address (`0x…`); omit it to send the native coin.
 - `--chain <key>` — Chain key (e.g. `base`, `ethereum`, `bsctestnet`). When set, `--token` is a token contract address. See **Selecting the chain & token** above.
-- `--confirm-to <address>` — Pin the expected resolved address. Transfer is rejected if ENS resolution returns a different address.
-- `--max-usd <n>` — Maximum allowed transfer value in USD (default: 10000). Transfer is rejected if value exceeds this.
+- `--decimals <n>` — Token decimals override (non-negative integer); use when auto-resolution fails for tokens not in the registry
+- `--confirm-to <address>` — Pin the expected resolved address. Rejected with `ENS_MISMATCH` only when name resolution changed the address and the result differs from the pin.
+- `--max-usd <n>` — Maximum allowed transfer value in USD (default: 10000). Exceeding it fails with `USD_LIMIT_EXCEEDED`.
 - `--skip-safety-check` — Bypass the USD value safety check
-- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--password <pw>` — Wallet password (falls back to `TWAK_WALLET_PASSWORD` env var, then OS keychain)
 - `--json` — Output as JSON
+
+## USD Safety Check
+
+Unless `--skip-safety-check` is set, the transfer's USD value is estimated from a price lookup. If it exceeds `--max-usd`, the transfer fails with `USD_LIMIT_EXCEEDED`. If the price lookup fails or returns 0, the check is **silently skipped** (a warning goes to stderr only) and the transfer proceeds — do not rely on `--max-usd` as a hard gate for tokens without price data. Values over $1000 print a high-value warning to stderr.
+
+## Errors
+
+With `--json`, errors emit a single `{ error, errorCode }` object to stdout and exit with code 1.
+
+| errorCode | Trigger |
+|---|---|
+| `VALIDATION_ERROR` | Asset ID combined with `--chain`; missing `--token` without `--chain`; malformed token ID; non-positive `--amount` or `--max-usd`; bad `--decimals`; decimals could not be determined |
+| `CHAIN_UNSUPPORTED` | Unknown `--chain` key, or unsupported coin ID in the asset ID |
+| `ENS_NOT_FOUND` | Dotted `--to` name could not be resolved |
+| `ENS_MISMATCH` | Resolved address differs from `--confirm-to` pin |
+| `TOKEN_NOT_FOUND` | Token could not be resolved on the target chain |
+| `USD_LIMIT_EXCEEDED` | Estimated USD value exceeds `--max-usd` |
+| `INSUFFICIENT_BALANCE` | Broadcast rejected for insufficient funds |
+| `NETWORK_ERROR` | Network/connection failure during broadcast |
+| `BROADCAST_FAILED` | RPC/broadcast rejected the transaction |
+| `SIGN_FAILED` | Signing failed |
+| `RATE_LIMITED` | API returned HTTP 429 |
 
 ## Supported Chains
 
@@ -95,7 +122,7 @@ Run `twak chains` for all supported chains and coin IDs.
 
 ## BSC Testnet
 
-`--chain bsctestnet` targets BSC testnet (chain ID 97). This testnet key is intentionally **not** listed by `twak chains` — it is enabled only for a limited set of operations: ERC-20 transfer/approve/balance and ERC-8004 / ERC-8183 contract calls. Swaps, portfolio, market data, and onramp stay mainnet-only.
+`--chain bsctestnet` targets BSC testnet (chain ID 97). This testnet key is intentionally **not** listed by `twak chains` — it is enabled only for a limited set of operations: native (tBNB) and ERC-20 transfers, ERC-20 approve/balance, and ERC-8004 / ERC-8183 contract calls. Swaps, portfolio, market data, and onramp stay mainnet-only.
 
 ```bash
 # Native tBNB transfer

--- a/skills/wallet/references/setup.md
+++ b/skills/wallet/references/setup.md
@@ -15,6 +15,22 @@ Verify installation:
 twak --version
 ```
 
+On failure, commands with `--json` emit `{ error, errorCode }` on stdout and exit 1.
+
+## Guided Setup (Interactive)
+
+```bash
+twak setup
+```
+
+Interactive alternative to the manual env-var + `twak init` flow below: prompts for API credentials, wires twak into AI harnesses, and creates a wallet. With no flags it runs all three phases; flags restrict it to specific phases:
+
+- `--reconfigure-creds` — re-prompt for API credentials even if already configured
+- `--harness <name>` — run only the harness phase for one harness
+- `--wallet` — run only the wallet phase
+
+Set `TWAK_NONINTERACTIVE=1` or `NO_PROMPT=1` to force non-interactive mode (also auto-detected when neither stdin nor stderr is a TTY). For scripted/agent setups, prefer the manual flow below.
+
 ## Authenticate
 
 ### Step 1: Check existing credentials
@@ -59,6 +75,14 @@ twak init
 ```
 
 This reads from the environment and saves to `~/.twak/credentials.json` (mode 0600) with the HMAC secret additionally stored in the OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Manager).
+
+`twak init` options:
+
+- `--wc-project-id <id>` — store a WalletConnect project ID alongside the credentials (also read from `WALLETCONNECT_PROJECT_ID`)
+- `--json` — JSON output: `{ configured: true, source: 'env' | 'cli' | 'file' }`; when `source` is `'file'` (existing config, nothing written) it also includes `accessIdPreview` and `walletConnectProjectId`
+- `--api-key <key>` / `--api-secret <secret>` — pass credentials directly; avoid these (shell history exposure), env vars are preferred
+
+With `--json` and no credentials available from flags, environment, or an existing config file, `init` fails with `errorCode: "VALIDATION_ERROR"`.
 
 ### Step 5: Verify
 

--- a/skills/wallet/references/swap.md
+++ b/skills/wallet/references/swap.md
@@ -22,11 +22,11 @@ twak swap 100 USDC USDC --chain ethereum --to-chain arbitrum --quote-only --json
 twak swap ETH USDC --chain ethereum --usd 100 --quote-only --json
 ```
 
-Only execute after the user confirms the quote.
+Only execute after the user confirms the quote. `--quote-only` needs no wallet or password.
 
 ## Execute a Swap
 
-Password is auto-resolved from OS keychain:
+Password resolution order: `--password` flag → `TWAK_WALLET_PASSWORD` env var → OS keychain. Passing `--password` prints a stderr warning (visible in shell history); prefer the env var or keychain:
 
 ```bash
 # Same-chain EVM
@@ -46,15 +46,52 @@ twak swap 0.01 ETH BNB --chain ethereum --to-chain bsc --json
 
 - `--chain <key>` — Source chain (default: ethereum)
 - `--to-chain <key>` — Destination chain for cross-chain swaps
-- `--slippage <pct>` — Slippage tolerance % (default: 1)
-- `--usd <amount>` — Swap a USD-equivalent amount of the source token (e.g. `twak swap ETH USDC --usd 100`)
+- `--slippage <pct>` — Slippage tolerance % (default: 1). Must be a positive number (`VALIDATION_ERROR` otherwise); values above 50 are rejected with `SLIPPAGE_EXCEEDED`; values above 5 emit a stderr warning but proceed
+- `--decimals <n>` — Source token decimals (overrides auto-resolution for tokens not in the registry)
+- `--usd <amount>` — Swap a USD-equivalent amount of the source token (e.g. `twak swap ETH USDC --usd 100`); fails with `NETWORK_ERROR` if the token price can't be fetched
 - `--quote-only` — Get quote without executing
-- `--password <pw>` — Wallet password (resolved from OS keychain if omitted)
+- `--password <pw>` — Wallet password (resolution order: `--password` → `TWAK_WALLET_PASSWORD` → OS keychain)
 - `--json` — Output as JSON
 
 ## Token Resolution
 
 Use token symbols (ETH, USDC, USDT, DAI, WETH, WBTC, SOL, BONK, JUP) or contract addresses. The CLI resolves symbols to addresses automatically.
+
+Asset IDs are also accepted: `c{coinId}` for native coins (e.g. `c60` = ETH) and `c{coinId}_t{contractAddress}` for tokens (e.g. `c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7` = USDT on Ethereum). An asset-ID **source** token overrides `--chain` with the chain derived from its coin ID; an asset-ID **destination** token overrides `--to-chain` the same way, but only when `--to-chain` is passed — without `--to-chain` the destination chain is always the source chain. An unrecognized coin ID fails with `CHAIN_UNSUPPORTED`.
+
+## JSON Output
+
+With `--json`, stdout carries **only** the JSON object — all status/progress messages (USD conversion, approval/swap tx links, high-slippage warning) go to stderr, so `twak swap … --json | jq` is safe.
+
+Quote (`--quote-only`): `{ input, output, minReceived?, provider, priceImpact, networkFee?, steps? }`
+
+- `input` / `output` — formatted strings with symbol, e.g. `"1.0 ETH"`, `"2543.21 USDC"`
+- `minReceived` — formatted string; omitted when the route has no min-amount-out
+- `provider` — provider names joined with `" → "` for multi-step routes, e.g. `"1inch"` or `"Stargate → 1inch"`
+- `priceImpact` — string
+- `networkFee` — formatted string, multiple step fees joined with `" + "` (e.g. `"0.001 ETH + 0.002 BNB"`); omitted when no step reports a fee
+- `steps` — number of route steps; only present for multi-step routes (> 1)
+
+Execute success: same keys as the quote, plus `{ hash, fromChain, toChain, explorer }` — `hash` is the swap transaction hash, `explorer` is the block-explorer URL.
+
+Error: `{ error, errorCode }` on stdout, exit code 1.
+
+## Error Codes
+
+- `VALIDATION_ERROR` — bad/missing amount, both `<amount>` and `--usd` given, non-positive `--slippage` or `--usd`
+- `SLIPPAGE_EXCEEDED` — `--slippage` above 50
+- `CHAIN_UNSUPPORTED` — unknown chain key or unknown coin ID in an asset-ID token
+- `TOKEN_NOT_FOUND` — token symbol not resolvable on the chain
+- `NETWORK_ERROR` — price fetch failed for `--usd`
+- `NO_ROUTES` — no swap routes found for the pair
+- `INSUFFICIENT_BALANCE` — on-chain execution failed for insufficient funds
+- `TX_FAILED` — transaction failed on-chain or was not confirmed in time
+- `APPROVAL_SENT_SWAP_FAILED` — the ERC-20 approval tx was broadcast but the swap itself failed; the approval tx hash is included in `error`. Check the allowance before retrying
+- `UNKNOWN_ERROR` — unclassified failure (last resort)
+
+## Approvals
+
+ERC-20 approvals are handled automatically during execution — no separate approve step is needed. The executor signs and broadcasts any `revokeApproval`/`approval` transactions returned by the routing API before the swap tx, and when none are returned it checks the on-chain allowance for the route's operator and auto-approves if it falls short. Each approval is confirmed (up to 60s) before the swap tx is sent (confirmed up to 120s). Approval tx links are logged to stderr.
 
 ## Chain Key vs Chain ID
 

--- a/skills/wallet/references/token-risk.md
+++ b/skills/wallet/references/token-risk.md
@@ -3,6 +3,8 @@
 
 Check token risk signals and validate wallet addresses before interacting with unfamiliar assets.
 
+On error, both commands emit `{ error, errorCode }` on stdout (with `--json`) and exit with code 1.
+
 ## Token Risk Check
 
 Checks for honeypot detection, audit status, freeze authority, and other security signals:
@@ -18,12 +20,15 @@ twak risk c60_t0xdAC17F958D2ee523a2206206994597C13D831ec7 --json  # USDT
 twak risk c60_t0x6982508145454Ce325dDbE47a25d4ec3d2311933 --json  # PEPE
 ```
 
+Unknown assetId → `errorCode: TOKEN_NOT_FOUND`.
+
 ## Address Validation
 
-Validate that an address is well-formed for its chain:
+Validate that an address is well-formed for its chain. Requires `--chain <key>` OR `--asset-id <id>`; with neither, fails with `VALIDATION_ERROR`:
 
 ```bash
-twak validate --address <addr> --json
+twak validate --address 0xdAC17F958D2ee523a2206206994597C13D831ec7 --chain ethereum --json
+twak validate --address <addr> --asset-id c501 --json
 ```
 
 ## When to Use

--- a/skills/wallet/references/wallet.md
+++ b/skills/wallet/references/wallet.md
@@ -3,6 +3,8 @@
 
 Non-custodial HD (BIP39) wallet that derives addresses across 25+ chains. Keys remain local — signing happens on-device and private keys never leave the machine.
 
+On failure, commands with `--json` emit `{ error, errorCode }` on stdout and exit 1.
+
 ## Prerequisites
 
 - Authenticated (`twak auth status`)
@@ -17,7 +19,7 @@ twak wallet create --password <pw> --skip-password-check    # skip strength vali
 
 Password must be at least 8 characters with mixed case and a number. Use `--skip-password-check` only for test wallets.
 
-Output includes derived addresses for all major chains.
+With `--json`, output is `{ addresses: [{ chainId, address }] }` — the derived address for every supported chain. Human output shows only the chain count. Fails with `WALLET_EXISTS` if a wallet already exists (back up and delete `~/.twak/wallet.json` to recreate).
 
 ## Get Addresses
 
@@ -26,13 +28,23 @@ twak wallet address --chain ethereum --json
 twak wallet addresses --json                # all chains
 ```
 
+Both accept `--password <pw>` (falls back to `TWAK_WALLET_PASSWORD` / OS keychain).
+
 ## Check Status
 
 ```bash
 twak wallet status --json
 ```
 
-Output: `{ agentWallet: bool, keychainPassword: bool, walletConnect: { connected, address } }`
+Output: `{ agentWallet: 'configured' | 'not configured', keychainPassword: 'stored' | 'not stored', chains, supportedChains, createdAt?, addressCount? }` — `chains` and `supportedChains` are numbers (count of supported chains); `createdAt` and `addressCount` appear only when a wallet exists.
+
+## Register with Backend
+
+```bash
+twak wallet register --json
+```
+
+Re-registers the wallet's addresses with the Trust Wallet backend (enables token holdings / portfolio tracking — `wallet create` does this automatically, but it can fail silently). Accepts `--password <pw>`. Output: `{ registered: true, chains }` (`chains` = number of registered addresses).
 
 ## Sign a Message
 
@@ -51,6 +63,8 @@ twak wallet keychain save --password <pw>
 twak wallet keychain check
 twak wallet keychain delete
 ```
+
+`keychain check --json` output: `{ available, stored }` (booleans — keychain availability on this system, and whether a password is stored).
 
 ## Password Resolution Order
 

--- a/skills/wallet/references/wallet.md
+++ b/skills/wallet/references/wallet.md
@@ -40,7 +40,7 @@ Output: `{ agentWallet: bool, keychainPassword: bool, walletConnect: { connected
 twak wallet sign-message --chain ethereum --message "hello world" --json
 ```
 
-Output: `{ chain, address, message, signature }`
+Output: `{ chain, address, message, signature, digest }` — on EVM chains the signature is `0x`-prefixed and `digest` is the EIP-191 hash the signature recovers against (verifiable with `cast hash-message` / `cast wallet verify`); non-EVM chains omit `digest`.
 
 ## Keychain Management
 

--- a/skills/wallet/references/x402.md
+++ b/skills/wallet/references/x402.md
@@ -14,7 +14,7 @@ twak x402 request <url> --max-payment <atomic>
 1. Client sends HTTP request without payment.
 2. Server returns `402 Payment Required` with a challenge listing one or more `accepts` entries (chain + asset + amount + transfer method).
 3. Client picker selects the best entry (EIP-3009 gasless preferred over Permit2). User confirms unless `--yes`.
-4. Client signs a payment authorization (EIP-3009 transferWithAuthorization) or Permit2 witness, attaches it to the `PAYMENT-SIGNATURE` header, and retries.
+4. Client signs a payment authorization (EIP-3009 transferWithAuthorization) or Permit2 witness, attaches it to the payment header — `X-PAYMENT` for V1 challenges, `PAYMENT-SIGNATURE` for V2 — and retries.
 5. Server verifies on-chain settlement and returns the resource.
 
 ### Examples
@@ -63,10 +63,10 @@ twak x402 request https://api.example.com/data \
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--max-payment <atomic>` | string (integer atomic units) | yes | Max payment to auto-approve, in atomic units of the chosen asset (e.g. `"10000"` = 0.01 USDC at 6dp; `"10000000000000000"` = 0.01 of an 18-dp token). |
-| `--method <method>` | `GET` \| `POST` \| `PUT` \| `DELETE` \| `HEAD` | no | HTTP method (default: `GET`). Body is stripped on `GET` and `HEAD`. |
+| `--method <method>` | string | no | HTTP method, uppercased before sending (default: `GET`). Not a fixed enum — any verb is accepted. Body is stripped on `GET` and `HEAD`. |
 | `--body <json>` | string | no | Raw request body. Sent verbatim with `Content-Type: application/json`. |
-| `--prefer-network <network>` | string | no | Restrict route to this chain. Accepts a TWAK chain key (`"base"`, `"bsc"`, `"ethereum"`, `"polygon"`, …) or a CAIP-2 string (`"eip155:8453"`). AND-combined with `--prefer-method`/`--prefer-asset`. |
-| `--prefer-method <method>` | `eip3009` \| `permit2-exact` | no | Restrict route to this transfer method. Default picker prefers `eip3009` (gasless) when offered. |
+| `--prefer-network <network>` | string | no | Restrict route to this chain. Accepts a TWAK chain key (`"base"`, `"bsc"`, `"ethereum"`, `"polygon"`, …), a CAIP-2 string (`"eip155:8453"`), or the seller's raw `network` string verbatim (e.g. a V1 challenge's `"smartchain"`). Case-insensitive. AND-combined with `--prefer-method`/`--prefer-asset`. |
+| `--prefer-method <method>` | `eip3009` \| `permit2-exact` \| `permit2` | no | Restrict route to this transfer method. `permit2` is an alias canonicalized to `permit2-exact` — either spelling matches entries advertised as either. Default picker prefers `eip3009` (gasless) when offered. |
 | `--prefer-asset <addr-or-name>` | string | no | Restrict route to this asset. Accepts a contract address (exact, case-insensitive) **or** a token-name substring matched against `extra.name` (`"Tether"`, `"USDC"`, `"United Stables"`). |
 | `--yes` | boolean | no | Skip the per-payment confirmation prompt. Still respects `--max-payment`. |
 | `--auto-approve` | boolean | no | Skip the Permit2 first-time approval prompt and broadcast `approve(Permit2, MAX)` (you pay gas; runs once per token+chain). Independent from `--yes`. |
@@ -78,12 +78,13 @@ twak x402 request https://api.example.com/data \
 | `errorCode` | When |
 |-------------|------|
 | `VALIDATION_ERROR` | `http://` URL, private/loopback IP, DNS rebind to a private IP, or invalid `--max-payment`. |
-| `CHAIN_UNSUPPORTED` | The 402 challenge offers a chain TWAK does not support. |
-| `NO_MATCHING_ROUTE` | One of `--prefer-network`/`--prefer-method`/`--prefer-asset` filtered out every offered entry. Message includes the active filters and the full offered list. |
+| `CHAIN_UNSUPPORTED` | The picked route's chain is not in TWAK's chain map. |
+| `NO_MATCHING_ROUTE` | One of `--prefer-network`/`--prefer-method`/`--prefer-asset` filtered out every offered entry. Message includes the active filters and the full offered list. Thrown only by the pre-filter — if entries survive the filter but none is signable, the code is `PAYMENT_INVALID_CHALLENGE` instead. |
 | `PAYMENT_AMOUNT_EXCEEDED` | Server's requested amount exceeds `--max-payment`. |
-| `PAYMENT_INVALID_CHALLENGE` | The 402 body/header is missing required fields or fails schema validation. |
+| `PAYMENT_INVALID_CHALLENGE` | The 402 body/header is missing required fields, fails schema validation, or no offered entry (after `--prefer-*` filtering) uses a scheme this client can sign (`no supported scheme in 402 response …`). |
 | `PAYMENT_CANCELLED` | User answered `n` at the confirmation prompt. |
-| `PERMIT2_APPROVAL_REQUIRED` | Permit2 route chosen, allowance is zero, user declined the approval prompt. |
+| `PERMIT2_APPROVAL_REQUIRED` | Permit2 route chosen, existing allowance is below the required amount, and the approval prompt was declined. |
+| `TX_FAILED` | The Permit2 approval tx reverted, or was not confirmed within 60s. |
 | `NETWORK_ERROR` | The server returned a non-2xx, non-402 status. |
 
 ## Quote — Preview Payment Options Without Signing
@@ -115,7 +116,7 @@ twak x402 quote https://api.example.com/data --json
 
 ### Output Shape
 
-Text mode renders a table sorted preferred-first (chains TWAK does not support are filtered out, with a `Filtered N route(s)` warning) plus a `Next:` line containing the literal `twak x402 request …` command you should run to pay. URL, `--method`, and `--body` are shell-quoted in the `Next:` line for safe copy-paste.
+Text mode renders a table sorted preferred-first plus a `Next:` line containing the literal `twak x402 request …` command you should run to pay. URL, `--method`, and `--body` are shell-quoted in the `Next:` line for safe copy-paste. Routes on chains TWAK does not recognize are dropped silently before rendering (no warning). If nothing remains, text mode prints `No supported route from this endpoint.` and exits `1`; if rows render but none is signable, it prints `No route here can be signed by this client.` and exits `1`.
 
 JSON mode emits the full `QuoteX402Result`:
 
@@ -127,7 +128,7 @@ JSON mode emits the full `QuoteX402Result`:
     "description": "…",
     "mimeType": "application/json"
   },
-  "accepts": [                          // Full unfiltered list — exactly what the endpoint offered.
+  "accepts": [                          // Already filtered: routes on chains TWAK does not recognize are dropped before output.
     {
       "network": "eip155:8453",         // CAIP-2 chain ID.
       "scheme": "exact",
@@ -152,7 +153,7 @@ Failure envelope (HTTPS validation failure, endpoint not a 402, malformed challe
 ```jsonc
 {
   "success": false,
-  "code": "NETWORK_ERROR",              // VALIDATION_ERROR / NO_PAYMENT_REQUIRED / PAYMENT_INVALID_CHALLENGE / CHAIN_UNSUPPORTED / NETWORK_ERROR
+  "code": "NETWORK_ERROR",              // VALIDATION_ERROR / NO_PAYMENT_REQUIRED / PAYMENT_INVALID_CHALLENGE / NETWORK_ERROR
   "message": "Endpoint returned 500 Internal Server Error; expected 402 challenge.",
   "status": 500,                        // HTTP status (when applicable)
   "error": "Endpoint returned 500 …",   // Same as `message`; legacy envelope key.
@@ -162,17 +163,21 @@ Failure envelope (HTTPS validation failure, endpoint not a 402, malformed challe
 
 ### Filtering Semantics
 
-The CLI text mode filters out routes on chains TWAK doesn't sign for (e.g. `eip155:196` X-Layer); the JSON output keeps the full unfiltered list under `accepts` so scripts can see exactly what the endpoint offered. Process exit code is `1` when filtering drops every route (i.e. the endpoint offered nothing this client can pay).
+Routes on chains TWAK does not recognize are dropped before **both** output modes — silently, with no warning. The JSON `accepts` array is already filtered; only `summary`/`nextAction` reference the original offered count, and only when every route was dropped (`Endpoint offered N payment option(s), but none on chains this client supports.`).
+
+Process exit code is `1` whenever no signable route remains, in both modes:
+- Every route dropped → text mode prints `No supported route from this endpoint.`
+- Routes remain on recognized chains but none uses a signable scheme (e.g. only `permit2-upto`) → text mode lists them, then prints `No route here can be signed by this client.`. JSON mode emits the raw library result: `success: true`, `preferred: false` on every `accepts` entry, a "no supported route" `nextAction`, and **no** `error`/`errorCode` keys. Detect this case by checking that no `accepts` entry has `preferred: true`.
 
 ### Sort Order
 
-Sorted preferred-first in both modes. If the preferred kind happens to be on a chain TWAK can't sign on, `preferred` is `false` for every entry and `nextAction` falls back to a "no supported route" message.
+Sorted preferred-first in both modes. `preferred` is `false` for every entry when no remaining route uses a scheme this client can sign (e.g. the endpoint only offers `permit2-upto`); the picker runs on the already chain-filtered set, so an unsupported chain never causes this. In that case `nextAction` falls back to a "no supported route" message.
 
 ### Quote Options
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--method <method>` | `GET` \| `POST` \| `PUT` \| `DELETE` \| `HEAD` | no | HTTP method (default: `GET`). Body is stripped on `GET` and `HEAD`. Must match the method you plan to use on `twak x402 request` — the server may emit a different 402 for a different verb. |
+| `--method <method>` | string | no | HTTP method, uppercased before sending (default: `GET`). Not a fixed enum — any verb is accepted. Body is stripped on `GET` and `HEAD`. Must match the method you plan to use on `twak x402 request` — the server may emit a different 402 for a different verb. |
 | `--body <json>` | string | no | Raw request body. Must match the body you plan to use on `twak x402 request`. |
 | `--json` | boolean | no | Emit the JSON shape above. Without `--json`, renders the human-readable table. |
 
@@ -183,13 +188,13 @@ Sorted preferred-first in both modes. If the preferred kind happens to be on a c
 When the server offers multiple `accepts` entries:
 
 1. **Filter** by `--prefer-network` / `--prefer-method` / `--prefer-asset` (AND-combined). Empty result → `NO_MATCHING_ROUTE`.
-2. **Skip unsignable entries.** Each kept entry must be a method the client can sign:
-   - EIP-3009 entries **require** `extra.name` and `extra.version` (used to build the EIP-712 domain separator). Entries missing either field are skipped entirely — not signable, even if they're the only EIP-3009 option offered.
-   - `permit2-exact` is signable as long as the chain is supported.
+2. **Skip unsignable entries.** Each kept entry must use scheme `exact` with a method the client can sign (`eip3009`, `permit2`, `permit2-exact`); anything else (e.g. `permit2-upto`) is skipped.
+   - EIP-3009 entries additionally **require** `extra.name` and `extra.version` (used to build the EIP-712 domain separator). Entries missing either field are skipped entirely — not signable, even if they're the only EIP-3009 option offered.
+   - `permit2` / `permit2-exact` entries (aliases for the same flow) need no extra metadata.
 3. **Prefer EIP-3009** over Permit2 among the surviving entries (no approval, no gas).
-4. **Fall back** to Permit2 (`permit2-exact`) on the first surviving entry. Requires a one-time `approve(Permit2, MAX)` if the wallet has not approved the token before.
+4. **Fall back** to Permit2 (`permit2` / `permit2-exact`) on the first surviving entry. Requires a one-time `approve(Permit2, MAX)` if the existing Permit2 allowance is below the payment amount.
 
-If filtering plus the signable check eliminate every entry, the picker returns `NO_MATCHING_ROUTE` (when an explicit `--prefer-*` flag is in play) or a generic "no supported route" error (when nothing the endpoint offered is signable).
+Error attribution: `NO_MATCHING_ROUTE` is thrown only when the `--prefer-*` pre-filter (step 1) removes every entry. If entries survive the filter but none is signable (step 2 onward), the error is `PAYMENT_INVALID_CHALLENGE` (`no supported scheme in 402 response …`).
 
 EIP-3009 is always cheaper for the buyer (no approval, no gas) so it wins by default whenever offered with valid metadata.
 
@@ -201,12 +206,12 @@ twak x402 info
 
 ## Supported Settlement Routes
 
-EIP-3009 settlement is supported on any EVM chain TWAK knows about where the token contract implements `transferWithAuthorization`. Permit2-exact is supported on any EVM chain Uniswap's Permit2 contract is deployed to. The picker delegates chain support to the TWAK chain map; offering an unsupported chain returns `CHAIN_UNSUPPORTED`.
+Route selection accepts any chain in TWAK's chain map; signing (EIP-3009 and Permit2) is EVM-only. EIP-3009 additionally requires the token contract to implement `transferWithAuthorization` — support is per-token, not per-chain. Permit2-exact requires Uniswap's Permit2 contract to be deployed on the chain. When the picked route's chain is not in the chain map, `twak x402 request` returns `CHAIN_UNSUPPORTED` (`quote` silently drops such routes instead).
 
-Common live routes (subject to merchant configuration):
+Example routes from live merchant endpoints (merchant-configured — verify with `twak x402 quote`, not guaranteed):
 
 | Asset | Chain | Method | Notes |
 |-------|-------|--------|-------|
 | USDC | `base` (`eip155:8453`) | EIP-3009 | Recommended — low fees, gasless, fast finality. |
-| USDC | `bsc` (`eip155:56`) | EIP-3009 / Permit2-exact | Available on most merchants. |
+| USDC | `bsc` (`eip155:56`) | EIP-3009 / Permit2-exact | |
 | USDT | `bsc` (`eip155:56`) | EIP-3009 / Permit2-exact | Atomic units at 18dp on BSC. |


### PR DESCRIPTION
## Description

Two parts, both verified claim-by-claim against the twak CLI source.

### 1. v0.19.0 feature updates

- **`erc8183.md`**: `--opt-params <hex>` on the six Commerce writes (with the protocol-critical `submit` guidance — the policy re-emits optParams in `JobInitialised`, where off-chain evaluators read the deliverable manifest), `fund --expected-budget` (race-free funding pin), new `policy-info <jobId>` command, and the new revert format (`{"error": "execution reverted: 0x<selector>", "errorCode": "TX_FAILED"}`).
- **`wallet.md`**: `sign-message` output now includes the EIP-191 `digest`; EVM signatures are `0x`-prefixed.

### 2. Full 1:1 audit of every wallet-skill reference (16 files, +354/−84)

An audit of all references against the CLI source found and fixed false claims, including:

- `balance.md` documented a **nonexistent `twak holdings` command** and a wrong `wallet balance` output shape (phantom `pending` key; missing `totalUsd`/`tokens`; `--all` returns an array).
- `wallet.md` documented `wallet status` as booleans + a `walletConnect` key — actual output is strings (`'configured'`/`'stored'`) with no such key.
- `token-risk.md`'s only `validate` example omitted the required `--chain`/`--asset-id` flag.
- `history.md` claimed `tx` includes an explorer URL (it doesn't) and missed its dual output shape.
- `x402.md`: removed a nonexistent "Filtered N route(s)" warning, fixed the "full unfiltered `accepts` list" claim, corrected error-code attribution (`PAYMENT_INVALID_CHALLENGE` vs `NO_MATCHING_ROUTE`), version-dependent payment header (`X-PAYMENT` V1 / `PAYMENT-SIGNATURE` V2), added the `permit2` method alias and `TX_FAILED`.
- `automations.md` interval format was missing the `d` (days) unit; `market.md` presented `dapps --category` as an enum (it's a substring match).
- `onramp.md`: `--max-usd` is best-effort (skipped on price-lookup failure); sell quotes are MoonPay-only; `--password` was missing from 4 of 5 subcommands.

And closed the systematic gaps:

- **JSON output schemas for every command** (exact keys, conditional/nullable fields noted).
- **Error-code catalogs per doc** with trigger conditions, plus the `{ error, errorCode }` + exit-1 envelope.
- Missing flags/commands documented: `--decimals` (transfer/swap), `wallet register`, `twak setup`, `serve` flags in SKILL.md, `COMPETITION_REGISTRY_ADDRESS`, `price --history`/batch mode, `dapps --search/--categories`, watch `--password`/`--auto-lock`, and the `--password` → `TWAK_WALLET_PASSWORD` → keychain resolution order everywhere it was incomplete.

## How to test

Spot-check any documented command/output against the CLI, e.g.:

```bash
twak wallet status --json           # strings + chains/supportedChains, no walletConnect key
twak validate --address 0x… --chain ethereum --json
twak erc8183 policy-info <jobId> --json
twak price ETH --history week --json
```